### PR TITLE
Add RALPH-CC.md: run ralph loop inside Claude Code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.lnb.env
+.lnb/

--- a/RALPH-CC.md
+++ b/RALPH-CC.md
@@ -46,7 +46,16 @@ minimum specified.
 
 1. Parse `max-iterations` and `task-file` from the user's message.
    Apply defaults for anything unspecified.
-2. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X"`.
+2. Derive the notebook context once, so every subsequent log call uses
+   the same value:
+
+   ```
+   Bash("jq -r '.branch // .project // \"ralph-dev\"' <task-file>")
+   ```
+
+   Capture stdout into `<context>`. This mirrors how `ralph-prep.sh`
+   derives it, so both runners agree on the context slug.
+3. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X, context=<context>"`.
    One line, nothing more.
 
 ### Loop
@@ -56,11 +65,14 @@ For `i` in `1..max-iterations`:
 1. **Build the prompt.** Call:
 
    ```
-   Bash("./ralph-prep.sh --iteration i --task-file <task-file>")
+   Bash("./ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>")
    ```
 
-   Capture the tool result's stdout. This is the filled prompt. Do not
-   read, quote, or summarize it — just hold it for the next step.
+   Pass the same `N` you parsed in Setup so the start log entry records
+   the cap alongside the iteration number (matches `ralph.sh`'s log
+   format). Capture the tool result's stdout. This is the filled
+   prompt. Do not read, quote, or summarize it — just hold it for the
+   next step.
 
 2. **Spawn the worker.** Call:
 
@@ -76,12 +88,15 @@ For `i` in `1..max-iterations`:
    ending with either `<promise>DONE</promise>` or
    `<promise>ALL_DONE</promise>`.
 
-3. **Check the return.** Inspect the subagent's final message:
+3. **Check the return.** Inspect the subagent's final message. **Check
+   `ALL_DONE` first — `<promise>ALL_DONE</promise>` contains
+   `<promise>DONE</promise>` as a substring, so the order is
+   load-bearing.** (Same reason `ralph.sh`'s grep checks `ALL_DONE`
+   before `DONE` at ralph.sh:~159.)
 
    - Contains `<promise>ALL_DONE</promise>`:
-     - Call `Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook emit --context <context> --type done --tags ralph-harness 'ralph-cc: all stories complete at iteration i'")`.
-       (Context comes from the task file's `branch` field; if unsure,
-       omit the emit — not critical.)
+     - Call `Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook emit --context <context> --type done --tags ralph-harness 'ralph-cc: all stories complete at iteration i'")`
+       using the `<context>` derived in Setup step 2.
      - Break the loop. Go to "Post-loop".
    - Contains `<promise>DONE</promise>`:
      - Say exactly: `"iteration i: DONE, continuing"`. One line.
@@ -94,7 +109,7 @@ For `i` in `1..max-iterations`:
 ### Post-loop
 
 1. If the loop ended on `ALL_DONE`, optionally query the notebook for a
-   summary:
+   summary, using the `<context>` derived in Setup step 2:
 
    ```
    Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook sql \"SELECT ts, type, issue, substr(content,1,200) FROM entries WHERE context='<context>' AND type IN ('start','done','impl','blocker') ORDER BY ts\"")

--- a/RALPH-CC.md
+++ b/RALPH-CC.md
@@ -1,0 +1,145 @@
+# Ralph Loop — Claude Code Session Edition
+
+Drop-in alternative to `./ralph.sh --max-iterations N`, designed to run
+entirely inside a live Claude Code chat session using the `Agent()`
+subagent tool instead of headless `claude -p`. Use this when `-p` mode
+is unavailable or restricted.
+
+Same `PROMPT.md`, same `tasks.json`, same `.lnb/` notebook, same
+`archive/` directory, same per-iteration semantics. The only thing that
+changes is who spawns the per-iteration agent.
+
+## How to invoke
+
+In a Claude Code chat, type one of:
+
+> follow RALPH-CC.md, max-iterations 10
+
+> follow RALPH-CC.md, max-iterations 5, task-file tasks.json
+
+Defaults when unspecified:
+
+- `max-iterations` = 10
+- `task-file` = `tasks.json`
+- `prompt` = `PROMPT.md`
+- `notebook` = `.lnb`
+
+## Prerequisites
+
+1. The main Claude Code session must be in `acceptEdits` permission mode
+   (or you must approve each subagent tool call manually). Subagents
+   inherit the parent session's permission mode. This replaces
+   `ralph.sh`'s `--permission-mode acceptEdits` flag.
+2. `ralph-prep.sh`, `ralph-lib.sh`, and `PROMPT.md` must exist in the
+   current directory. `tasks.json` must exist and contain the stories to
+   work through.
+3. `ralph-prep.sh` must be executable (`chmod +x ralph-prep.sh`).
+4. `jq` and `lab-notebook` must be on `$PATH` (same as for `ralph.sh`).
+
+## Procedure for the main Claude Code session
+
+When the user invokes this file, the main session (you) must do the
+following. Do not deviate, do not add steps, do not narrate beyond the
+minimum specified.
+
+### Setup
+
+1. Parse `max-iterations` and `task-file` from the user's message.
+   Apply defaults for anything unspecified.
+2. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X"`.
+   One line, nothing more.
+
+### Loop
+
+For `i` in `1..max-iterations`:
+
+1. **Build the prompt.** Call:
+
+   ```
+   Bash("./ralph-prep.sh --iteration i --task-file <task-file>")
+   ```
+
+   Capture the tool result's stdout. This is the filled prompt. Do not
+   read, quote, or summarize it — just hold it for the next step.
+
+2. **Spawn the worker.** Call:
+
+   ```
+   Agent(
+       subagent_type="general-purpose",
+       description="ralph iteration i",
+       prompt=<stdout from step 1>
+   )
+   ```
+
+   The subagent will complete one story and return a final message
+   ending with either `<promise>DONE</promise>` or
+   `<promise>ALL_DONE</promise>`.
+
+3. **Check the return.** Inspect the subagent's final message:
+
+   - Contains `<promise>ALL_DONE</promise>`:
+     - Call `Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook emit --context <context> --type done --tags ralph-harness 'ralph-cc: all stories complete at iteration i'")`.
+       (Context comes from the task file's `branch` field; if unsure,
+       omit the emit — not critical.)
+     - Break the loop. Go to "Post-loop".
+   - Contains `<promise>DONE</promise>`:
+     - Say exactly: `"iteration i: DONE, continuing"`. One line.
+     - Continue to next iteration.
+   - Neither marker:
+     - Call `Bash(...)` to log a blocker entry (same shape as above but
+       `--type blocker` and `"ralph-cc: iteration i ended without promise"`).
+     - Break the loop. Go to "Post-loop".
+
+### Post-loop
+
+1. If the loop ended on `ALL_DONE`, optionally query the notebook for a
+   summary:
+
+   ```
+   Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook sql \"SELECT ts, type, issue, substr(content,1,200) FROM entries WHERE context='<context>' AND type IN ('start','done','impl','blocker') ORDER BY ts\"")
+   ```
+
+   Report a 3-5 sentence summary to the user covering what each story
+   accomplished.
+
+2. If the loop ended on `max-iterations`, report:
+   `"Hit iteration cap (N). Stopped. Check .lnb/ for progress."`
+
+3. If the loop ended on a missing marker, report:
+   `"Iteration i returned without a promise marker. Stopped. Check .lnb/ for the blocker entry and the subagent's final message."`
+
+## Stop conditions (summary)
+
+- `<promise>ALL_DONE</promise>` seen → success.
+- `max-iterations` reached → capped.
+- No promise marker in a subagent return → blocker.
+
+## Context budgeting
+
+Each iteration adds ~50 tokens (the subagent's final narration plus the
+promise marker) to the main session's context. A 20-iteration run is
+roughly 1k tokens — acceptable. Keep your own between-iteration
+narration to one short line ("iteration i: DONE, continuing"). Do not
+summarize subagent output, do not re-read `tasks.json` yourself
+(`ralph-prep.sh` already does it every iteration), do not print anything
+the user doesn't need.
+
+## Differences from `ralph.sh`
+
+| Aspect | `ralph.sh` | This flow |
+|---|---|---|
+| Entry | terminal: `./ralph.sh --max-iterations N` | chat: "follow RALPH-CC.md, max-iterations N" |
+| Per-iter agent | `claude -p --permission-mode acceptEdits` | `Agent(subagent_type="general-purpose")` |
+| Permission mode | CLI flag | inherited from main session |
+| Intermediate display | stream-json via `format_stream` | native Claude Code subagent UI |
+| Stop on no marker | no (only stops on non-zero exit code) | yes |
+| Main-session context cost | 0 | ~50 tokens/iter |
+| State storage | same | same |
+
+## Relationship to `ralph-lib.sh`
+
+`ralph-prep.sh` sources `ralph-lib.sh` for the same helper functions
+that `ralph.sh` uses (`read_task_meta`, `archive_previous_run`,
+`ensure_notebook`, `log_to_notebook`, `query_recent_history`,
+`build_prompt`). A change to `ralph-lib.sh` affects both runners.

--- a/RALPH-CC.md
+++ b/RALPH-CC.md
@@ -30,9 +30,12 @@ Defaults when unspecified:
    (or you must approve each subagent tool call manually). Subagents
    inherit the parent session's permission mode. This replaces
    `ralph.sh`'s `--permission-mode acceptEdits` flag.
-2. `ralph-prep.sh`, `ralph-lib.sh`, and `PROMPT.md` must exist in the
-   current directory. `tasks.json` must exist and contain the stories to
-   work through.
+2. `ralph-prep.sh`, `ralph-lib.sh`, `PROMPT.md`, and `coding-dev.yaml`
+   must exist in the current directory. `tasks.json` must exist and
+   contain the stories to work through. (`coding-dev.yaml` is the
+   lab-notebook schema — without it, `ensure_notebook` falls back to
+   the default `research-notebook` schema and agents log with the
+   wrong type vocabulary.)
 3. `ralph-prep.sh` must be executable (`chmod +x ralph-prep.sh`).
 4. `jq` and `lab-notebook` must be on `$PATH` (same as for `ralph.sh`).
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ Then pick one runner:
 **Inside a Claude Code session** (uses the `Agent()` subagent tool — no `-p` needed):
 
 ```bash
-# Copy the driver doc + helper scripts into your project
-cp ~/codes/ralph-wiggum-lnb/{RALPH-CC.md,ralph-prep.sh,ralph-lib.sh} .
+# Copy the driver doc + helper scripts + notebook schema into your project
+cp ~/codes/ralph-wiggum-lnb/{RALPH-CC.md,ralph-prep.sh,ralph-lib.sh,coding-dev.yaml} .
 chmod +x ralph-prep.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,27 @@ cp ~/codes/ralph-wiggum-lnb/tasks.json.example tasks.json
 # Initialize notebook with coding schema
 mkdir -p .lnb && cp ~/codes/ralph-wiggum-lnb/coding-dev.yaml .lnb/schema.yaml
 lab-notebook init .lnb
+```
 
-# Run
+Then pick one runner:
+
+**Headless** (uses `claude -p`):
+
+```bash
 ~/codes/ralph-wiggum-lnb/ralph.sh --max-iterations 5
 ```
+
+**Inside a Claude Code session** (uses the `Agent()` subagent tool — no `-p` needed):
+
+```bash
+# Copy the driver doc + helper scripts into your project
+cp ~/codes/ralph-wiggum-lnb/{RALPH-CC.md,ralph-prep.sh,ralph-lib.sh} .
+chmod +x ralph-prep.sh
+```
+
+Start Claude Code in `acceptEdits` mode, then in the session:
+
+> follow RALPH-CC.md, max-iterations 5
 
 ## How It Works
 
@@ -31,7 +48,7 @@ tasks.json (what to do)  +  .lnb/ (what happened)  +  PROMPT.md (how to do it)
            │                       │                           │
            └───────────┬───────────┘                           │
                        ▼                                       │
-              ralph.sh builds prompt ◄─────────────────────────┘
+              runner   builds prompt ◄─────────────────────────┘
                      │
               ┌──────┴──────────────────────┐
               │  for each iteration:        │
@@ -45,11 +62,29 @@ tasks.json (what to do)  +  .lnb/ (what happened)  +  PROMPT.md (how to do it)
               └─────────────────────────────┘
 ```
 
+## Two runners, same loop
+
+Ralph ships two entry points that share the same `PROMPT.md`, `tasks.json`,
+`.lnb/`, and `archive/` state:
+
+- **`ralph.sh`** — the original. Runs in a terminal, spawns a fresh
+  `claude -p` per iteration. Truly stateless outer loop.
+- **`RALPH-CC.md`** — drop-in alternative that runs inside a live Claude
+  Code chat session and uses the `Agent()` subagent tool. Use when `-p`
+  mode is unavailable or restricted. See `RALPH-CC.md` for the full
+  invocation recipe and stop-condition semantics.
+
+Both modes complete one story per iteration, emit `<promise>DONE</promise>`
+or `<promise>ALL_DONE</promise>`, and keep state in the same places.
+
 ## Files
 
 | File | Purpose |
 |------|---------|
-| `ralph.sh` | Runner script — the loop |
+| `ralph.sh` | Headless runner — uses `claude -p` |
+| `ralph-lib.sh` | Shared bash helpers sourced by `ralph.sh` and `ralph-prep.sh` |
+| `ralph-prep.sh` | Per-iteration bookkeeping + prompt builder; stdout is the filled prompt |
+| `RALPH-CC.md` | Driver doc for the Claude Code session runner |
 | `PROMPT.md` | Prompt template with `<!-- FILL:xxx -->` markers |
 | `tasks.json` | Your stories with `passes` flags (copy from `tasks.json.example`) |
 | `coding-dev.yaml` | Lab-notebook schema for code dev workflows |
@@ -107,7 +142,7 @@ LAB_NOTEBOOK_DIR=.lnb lab-notebook sql \
   "SELECT content FROM entries WHERE type='pattern' ORDER BY ts"
 ```
 
-## Options
+## `ralph.sh` options
 
 ```
 --max-iterations N      Safety cap (default: 10)
@@ -118,7 +153,11 @@ LAB_NOTEBOOK_DIR=.lnb lab-notebook sql \
 --archive-dir DIR       Archive directory (default: archive/)
 ```
 
+For the Claude Code session runner, `max-iterations`, `task-file`, and
+related parameters are passed inline when invoking the driver doc — see
+`RALPH-CC.md`.
+
 ## Archive
 
-When the `branch` field in `tasks.json` changes between runs, Ralph archives
-the previous task file and notebook to `archive/<date>-<branch>/`.
+When the `branch` field in `tasks.json` changes between runs, both runners
+archive the previous task file and notebook to `archive/<date>-<branch>/`.

--- a/ralph-lib.sh
+++ b/ralph-lib.sh
@@ -38,13 +38,36 @@ archive_previous_run() {
 # --- Notebook helpers ---
 ensure_notebook() {
     if [[ ! -d "$NOTEBOOK_DIR" ]]; then
-        if [[ -f "$SCRIPT_DIR/coding-dev.yaml" ]]; then
-            mkdir -p "$NOTEBOOK_DIR"
-            cp "$SCRIPT_DIR/coding-dev.yaml" "$NOTEBOOK_DIR/schema.yaml"
-            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init "$NOTEBOOK_DIR" >/dev/null 2>&1 || true
-        else
-            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init --local >/dev/null 2>&1 || true
+        # `lab-notebook init` (no positional arg) reliably creates
+        # `.lnb/` in cwd. Passing a positional arg triggers a
+        # path-doubling quirk that nests the real notebook at
+        # `<dir>/.lnb`, leaving any pre-placed schema.yaml as a ghost
+        # file. Stick with the default, then rename if the caller
+        # wanted a non-default notebook name.
+        lab-notebook init >/dev/null 2>&1 || true
+
+        if [[ "$NOTEBOOK_DIR" != ".lnb" && -d ".lnb" && ! -d "$NOTEBOOK_DIR" ]]; then
+            mv .lnb "$NOTEBOOK_DIR"
+            # Keep .lnb.env pointing at the renamed notebook so
+            # lab-notebook calls without an explicit LAB_NOTEBOOK_DIR
+            # env var still find it.
+            if [[ -f .lnb.env ]]; then
+                sed -i.bak "s|/\\.lnb$|/$NOTEBOOK_DIR|" .lnb.env && rm -f .lnb.env.bak
+            fi
         fi
+
+        # lab-notebook init installs its default schema
+        # (`research-notebook`). Overwrite with coding-dev.yaml when
+        # available, then rebuild the index so the SQLite type
+        # vocabulary matches. If coding-dev.yaml isn't available,
+        # warn once on stderr — ralph agents expect coding-dev types.
+        if [[ -f "$SCRIPT_DIR/coding-dev.yaml" && -d "$NOTEBOOK_DIR" ]]; then
+            cp "$SCRIPT_DIR/coding-dev.yaml" "$NOTEBOOK_DIR/schema.yaml"
+            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook rebuild >/dev/null 2>&1 || true
+        else
+            echo "Warning: $SCRIPT_DIR/coding-dev.yaml not found — notebook uses lab-notebook's default schema (research-notebook). Ralph agents expect coding-dev types (start/plan/impl/test/done)." >&2
+        fi
+
         echo "Initialized notebook at $NOTEBOOK_DIR" >&2
     fi
 }

--- a/ralph-lib.sh
+++ b/ralph-lib.sh
@@ -41,9 +41,9 @@ ensure_notebook() {
         if [[ -f "$SCRIPT_DIR/coding-dev.yaml" ]]; then
             mkdir -p "$NOTEBOOK_DIR"
             cp "$SCRIPT_DIR/coding-dev.yaml" "$NOTEBOOK_DIR/schema.yaml"
-            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init "$NOTEBOOK_DIR" >&2 2>/dev/null || true
+            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init "$NOTEBOOK_DIR" >/dev/null 2>&1 || true
         else
-            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init --local >&2 2>/dev/null || true
+            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init --local >/dev/null 2>&1 || true
         fi
         echo "Initialized notebook at $NOTEBOOK_DIR" >&2
     fi
@@ -62,8 +62,12 @@ log_to_notebook() {
 
 query_recent_history() {
     if command -v lab-notebook &>/dev/null && [[ -d "$NOTEBOOK_DIR" ]]; then
+        # Double up any single quotes in CONTEXT (SQL-standard escape)
+        # so a branch like ralph/feature's-test can't break out of the
+        # WHERE clause.
+        local escaped_context="${CONTEXT//\'/\'\'}"
         LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook sql \
-            "SELECT ts, type, issue, substr(content,1,200) FROM entries WHERE context='$CONTEXT' ORDER BY ts DESC LIMIT 10" \
+            "SELECT ts, type, issue, substr(content,1,200) FROM entries WHERE context='$escaped_context' ORDER BY ts DESC LIMIT 10" \
             2>/dev/null || echo "(no history yet)"
     else
         echo "(notebook not available)"

--- a/ralph-lib.sh
+++ b/ralph-lib.sh
@@ -1,0 +1,90 @@
+# Shared helpers for ralph.sh and ralph-prep.sh.
+# Source this file after defining: SCRIPT_DIR, PROMPT_FILE, TASK_FILE,
+# NOTEBOOK_DIR, CONTEXT, ARCHIVE_DIR, LAST_BRANCH_FILE. The functions
+# below also use BRANCH and PROJECT, which callers typically resolve via
+# read_task_meta after sourcing.
+
+# --- Read task file metadata ---
+read_task_meta() {
+    local key="$1"
+    jq -r ".$key // empty" "$TASK_FILE" 2>/dev/null || echo ""
+}
+
+# --- Archive support ---
+archive_previous_run() {
+    if [[ -f "$TASK_FILE" && -f "$LAST_BRANCH_FILE" ]]; then
+        local last_branch
+        last_branch=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
+        if [[ -n "$BRANCH" && -n "$last_branch" && "$BRANCH" != "$last_branch" ]]; then
+            local date_str folder_name archive_folder
+            date_str=$(date +%Y-%m-%d)
+            folder_name=$(echo "$last_branch" | sed 's|^ralph/||; s|/|-|g')
+            archive_folder="$ARCHIVE_DIR/$date_str-$folder_name"
+
+            echo "Archiving previous run: $last_branch" >&2
+            mkdir -p "$archive_folder"
+            cp "$TASK_FILE" "$archive_folder/"
+            if [[ -d "$NOTEBOOK_DIR" ]]; then
+                cp -r "$NOTEBOOK_DIR" "$archive_folder/"
+            fi
+            echo "  Archived to: $archive_folder" >&2
+        fi
+    fi
+    if [[ -n "$BRANCH" ]]; then
+        echo "$BRANCH" > "$LAST_BRANCH_FILE"
+    fi
+}
+
+# --- Notebook helpers ---
+ensure_notebook() {
+    if [[ ! -d "$NOTEBOOK_DIR" ]]; then
+        if [[ -f "$SCRIPT_DIR/coding-dev.yaml" ]]; then
+            mkdir -p "$NOTEBOOK_DIR"
+            cp "$SCRIPT_DIR/coding-dev.yaml" "$NOTEBOOK_DIR/schema.yaml"
+            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init "$NOTEBOOK_DIR" >&2 2>/dev/null || true
+        else
+            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init --local >&2 2>/dev/null || true
+        fi
+        echo "Initialized notebook at $NOTEBOOK_DIR" >&2
+    fi
+}
+
+log_to_notebook() {
+    local entry_type="$1"
+    local message="$2"
+    if command -v lab-notebook &>/dev/null && [[ -d "$NOTEBOOK_DIR" ]]; then
+        LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook emit \
+            --context "$CONTEXT" --type "$entry_type" \
+            --branch "${BRANCH:-}" --tags "ralph-harness" \
+            "$message" 2>/dev/null || true
+    fi
+}
+
+query_recent_history() {
+    if command -v lab-notebook &>/dev/null && [[ -d "$NOTEBOOK_DIR" ]]; then
+        LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook sql \
+            "SELECT ts, type, issue, substr(content,1,200) FROM entries WHERE context='$CONTEXT' ORDER BY ts DESC LIMIT 10" \
+            2>/dev/null || echo "(no history yet)"
+    else
+        echo "(notebook not available)"
+    fi
+}
+
+# --- Prompt building ---
+build_prompt() {
+    local history="$1"
+    local tasks_content
+    tasks_content=$(cat "$TASK_FILE")
+
+    local prompt
+    prompt=$(cat "$PROMPT_FILE")
+
+    # Replace FILL markers
+    prompt="${prompt//<!-- FILL:context -->/$CONTEXT}"
+    prompt="${prompt//<!-- FILL:notebook_dir -->/$NOTEBOOK_DIR}"
+    prompt="${prompt//<!-- FILL:branch -->/${BRANCH:-main}}"
+    prompt="${prompt//<!-- FILL:tasks -->/$tasks_content}"
+    prompt="${prompt//<!-- FILL:recent_history -->/$history}"
+
+    echo "$prompt"
+}

--- a/ralph-prep.sh
+++ b/ralph-prep.sh
@@ -12,6 +12,7 @@ NOTEBOOK_DIR=".lnb"
 CONTEXT=""
 ARCHIVE_DIR="archive"
 ITERATION="1"
+MAX_ITERATIONS=""
 LAST_BRANCH_FILE=".ralph-last-branch"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -33,6 +34,10 @@ Options:
   --archive-dir DIR       Where to archive old runs (default: archive/)
   --iteration N           Iteration number, used in the start log entry
                           (default: 1)
+  --max-iterations N      Iteration cap, recorded alongside --iteration
+                          in the start log entry (optional). Does not
+                          affect the loop — the Claude Code session
+                          enforces the cap via RALPH-CC.md.
   -h, --help              Show this help
 EOF
     exit 0
@@ -47,6 +52,7 @@ while [[ $# -gt 0 ]]; do
         --context)         CONTEXT="$2"; shift 2 ;;
         --archive-dir)     ARCHIVE_DIR="$2"; shift 2 ;;
         --iteration)       ITERATION="$2"; shift 2 ;;
+        --max-iterations)  MAX_ITERATIONS="$2"; shift 2 ;;
         -h|--help)         usage ;;
         *)                 echo "Unknown option: $1" >&2; usage ;;
     esac
@@ -89,7 +95,11 @@ fi
 archive_previous_run
 ensure_notebook
 
-log_to_notebook "start" "ralph-cc: starting iteration $ITERATION"
+if [[ -n "$MAX_ITERATIONS" ]]; then
+    log_to_notebook "start" "ralph-cc: starting iteration $ITERATION/$MAX_ITERATIONS"
+else
+    log_to_notebook "start" "ralph-cc: starting iteration $ITERATION"
+fi
 
 # --- Emit filled prompt to stdout ---
 history=$(query_recent_history)

--- a/ralph-prep.sh
+++ b/ralph-prep.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Per-iteration bookkeeping + prompt builder for RALPH-CC.md.
+# Prints the filled prompt to stdout so a Claude Code session can capture
+# it and pass it to Agent(). Diagnostics go to stderr.
+
+# --- Defaults ---
+PROMPT_FILE="PROMPT.md"
+TASK_FILE="tasks.json"
+NOTEBOOK_DIR=".lnb"
+CONTEXT=""
+ARCHIVE_DIR="archive"
+ITERATION="1"
+LAST_BRANCH_FILE=".ralph-last-branch"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    cat <<'EOF' >&2
+Usage: ralph-prep.sh [OPTIONS]
+
+Runs one iteration of ralph bookkeeping (archive, notebook init, history
+query, prompt fill) and prints the filled PROMPT.md to stdout. Intended
+to be invoked by a Claude Code session that then passes the stdout to
+the Agent() tool — see RALPH-CC.md.
+
+Options:
+  --prompt FILE           Prompt template (default: PROMPT.md)
+  --task-file FILE        Task file with stories (default: tasks.json)
+  --notebook DIR          Lab-notebook directory (default: .lnb)
+  --context SLUG          Notebook context (default: derived from branch)
+  --archive-dir DIR       Where to archive old runs (default: archive/)
+  --iteration N           Iteration number, used in the start log entry
+                          (default: 1)
+  -h, --help              Show this help
+EOF
+    exit 0
+}
+
+# --- Parse arguments ---
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --prompt)          PROMPT_FILE="$2"; shift 2 ;;
+        --task-file)       TASK_FILE="$2"; shift 2 ;;
+        --notebook)        NOTEBOOK_DIR="$2"; shift 2 ;;
+        --context)         CONTEXT="$2"; shift 2 ;;
+        --archive-dir)     ARCHIVE_DIR="$2"; shift 2 ;;
+        --iteration)       ITERATION="$2"; shift 2 ;;
+        -h|--help)         usage ;;
+        *)                 echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+# --- Validate ---
+if [[ ! -f "$PROMPT_FILE" ]]; then
+    echo "Error: Prompt file '$PROMPT_FILE' not found." >&2
+    echo "Copy the template: cp $SCRIPT_DIR/PROMPT.md ." >&2
+    exit 1
+fi
+
+if [[ ! -f "$TASK_FILE" ]]; then
+    echo "Error: Task file '$TASK_FILE' not found." >&2
+    echo "Copy the example: cp $SCRIPT_DIR/tasks.json.example tasks.json" >&2
+    exit 1
+fi
+
+# --- Load shared helpers ---
+source "$SCRIPT_DIR/ralph-lib.sh"
+
+# --- Read task file metadata ---
+BRANCH=$(read_task_meta "branch")
+PROJECT=$(read_task_meta "project")
+
+if [[ -z "$CONTEXT" ]]; then
+    if [[ -n "$BRANCH" ]]; then
+        CONTEXT="$BRANCH"
+    elif [[ -n "$PROJECT" ]]; then
+        CONTEXT="$PROJECT"
+    else
+        CONTEXT="ralph-dev"
+    fi
+fi
+
+# --- Bookkeeping ---
+# archive_previous_run and ensure_notebook are both idempotent — safe to
+# call on every iteration. archive_previous_run only actually archives
+# when BRANCH differs from $LAST_BRANCH_FILE's contents.
+archive_previous_run
+ensure_notebook
+
+log_to_notebook "start" "ralph-cc: starting iteration $ITERATION"
+
+# --- Emit filled prompt to stdout ---
+history=$(query_recent_history)
+build_prompt "$history"

--- a/ralph.sh
+++ b/ralph.sh
@@ -80,12 +80,11 @@ else
     exit 1
 fi
 
-# --- Read task file metadata ---
-read_task_meta() {
-    local key="$1"
-    jq -r ".$key // empty" "$TASK_FILE" 2>/dev/null || echo ""
-}
+# --- Shared helpers ---
+LAST_BRANCH_FILE=".ralph-last-branch"
+source "$SCRIPT_DIR/ralph-lib.sh"
 
+# --- Read task file metadata ---
 BRANCH=$(read_task_meta "branch")
 PROJECT=$(read_task_meta "project")
 
@@ -98,87 +97,6 @@ if [[ -z "$CONTEXT" ]]; then
         CONTEXT="ralph-dev"
     fi
 fi
-
-# --- Archive support ---
-LAST_BRANCH_FILE=".ralph-last-branch"
-
-archive_previous_run() {
-    if [[ -f "$TASK_FILE" && -f "$LAST_BRANCH_FILE" ]]; then
-        local last_branch
-        last_branch=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
-        if [[ -n "$BRANCH" && -n "$last_branch" && "$BRANCH" != "$last_branch" ]]; then
-            local date_str folder_name archive_folder
-            date_str=$(date +%Y-%m-%d)
-            folder_name=$(echo "$last_branch" | sed 's|^ralph/||; s|/|-|g')
-            archive_folder="$ARCHIVE_DIR/$date_str-$folder_name"
-
-            echo "Archiving previous run: $last_branch"
-            mkdir -p "$archive_folder"
-            cp "$TASK_FILE" "$archive_folder/"
-            if [[ -d "$NOTEBOOK_DIR" ]]; then
-                cp -r "$NOTEBOOK_DIR" "$archive_folder/"
-            fi
-            echo "  Archived to: $archive_folder"
-        fi
-    fi
-    if [[ -n "$BRANCH" ]]; then
-        echo "$BRANCH" > "$LAST_BRANCH_FILE"
-    fi
-}
-
-# --- Notebook helpers ---
-ensure_notebook() {
-    if [[ ! -d "$NOTEBOOK_DIR" ]]; then
-        if [[ -f "$SCRIPT_DIR/coding-dev.yaml" ]]; then
-            mkdir -p "$NOTEBOOK_DIR"
-            cp "$SCRIPT_DIR/coding-dev.yaml" "$NOTEBOOK_DIR/schema.yaml"
-            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init "$NOTEBOOK_DIR" 2>/dev/null || true
-        else
-            LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook init --local 2>/dev/null || true
-        fi
-        echo "Initialized notebook at $NOTEBOOK_DIR"
-    fi
-}
-
-log_to_notebook() {
-    local entry_type="$1"
-    local message="$2"
-    if command -v lab-notebook &>/dev/null && [[ -d "$NOTEBOOK_DIR" ]]; then
-        LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook emit \
-            --context "$CONTEXT" --type "$entry_type" \
-            --branch "${BRANCH:-}" --tags "ralph-harness" \
-            "$message" 2>/dev/null || true
-    fi
-}
-
-query_recent_history() {
-    if command -v lab-notebook &>/dev/null && [[ -d "$NOTEBOOK_DIR" ]]; then
-        LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook sql \
-            "SELECT ts, type, issue, substr(content,1,200) FROM entries WHERE context='$CONTEXT' ORDER BY ts DESC LIMIT 10" \
-            2>/dev/null || echo "(no history yet)"
-    else
-        echo "(notebook not available)"
-    fi
-}
-
-# --- Prompt building ---
-build_prompt() {
-    local history="$1"
-    local tasks_content
-    tasks_content=$(cat "$TASK_FILE")
-
-    local prompt
-    prompt=$(cat "$PROMPT_FILE")
-
-    # Replace FILL markers
-    prompt="${prompt//<!-- FILL:context -->/$CONTEXT}"
-    prompt="${prompt//<!-- FILL:notebook_dir -->/$NOTEBOOK_DIR}"
-    prompt="${prompt//<!-- FILL:branch -->/${BRANCH:-main}}"
-    prompt="${prompt//<!-- FILL:tasks -->/$tasks_content}"
-    prompt="${prompt//<!-- FILL:recent_history -->/$history}"
-
-    echo "$prompt"
-}
 
 # --- Output formatting ---
 format_stream() {

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,59 @@
+# Smoke tests
+
+Smoke test for the ralph loop against a throwaway 2-story fixture.
+Exercises both modes so you can verify `RALPH-CC.md` and `ralph.sh`
+still work end-to-end after editing `ralph-lib.sh`, `PROMPT.md`, etc.
+
+## Files
+
+- `tasks.json` — 2-story fixture (create `hello.txt`, append a line)
+- `setup-sandbox.sh` — scaffolds a timestamped sandbox under `$TMPDIR`
+
+## Running in Claude Code (non-headless)
+
+1. From the repo root: `./tests/setup-sandbox.sh`. Note the sandbox
+   path it prints.
+2. Open a new session in the sandbox:
+   ```
+   cd /tmp/ralph-smoke-YYYYMMDD-HHMMSS && claude
+   ```
+3. Make sure the session is in `acceptEdits` mode (Shift+Tab, or
+   `/permissions`). Subagents inherit the main session's permission
+   mode, so this replaces `ralph.sh`'s `--permission-mode acceptEdits`
+   flag.
+4. In the session: `follow RALPH-CC.md, max-iterations 3`
+5. Expected: Claude creates `hello.txt` with the two expected lines
+   and reports `ALL_DONE` within 2 iterations.
+6. Verify:
+   ```
+   cat hello.txt
+   jq '.stories[].passes' tasks.json   # both should be true
+   ls .lnb/
+   ```
+
+## Running headless
+
+```
+cd /tmp/ralph-smoke-YYYYMMDD-HHMMSS && ./ralph.sh --max-iterations 3
+```
+
+See `../RALPH-CC.md` and `../ralph.sh --help` for details on each mode.
+
+## Cleanup
+
+```
+rm -rf /tmp/ralph-smoke-*
+```
+
+Sandboxes are timestamped, so old runs are never overwritten.
+
+## Gotchas
+
+- Needs `jq` and `lab-notebook` on `$PATH` (same prerequisites as
+  ralph itself).
+- The sandbox symlinks scripts from the repo, so uncommitted changes
+  to `ralph-lib.sh` / `PROMPT.md` / etc. affect the test. This is by
+  design — smoke tests validate the current source tree.
+- The fixture's `branch: "ralph/smoke-test"` is just a label used for
+  the notebook context and prompt substitution. Ralph does not run
+  `git checkout`.

--- a/tests/setup-sandbox.sh
+++ b/tests/setup-sandbox.sh
@@ -6,7 +6,7 @@ SANDBOX="${TMPDIR:-/tmp}/ralph-smoke-$(date +%Y%m%d-%H%M%S)"
 
 mkdir -p "$SANDBOX"
 
-for f in PROMPT.md ralph.sh ralph-prep.sh ralph-lib.sh RALPH-CC.md; do
+for f in PROMPT.md ralph.sh ralph-prep.sh ralph-lib.sh RALPH-CC.md coding-dev.yaml; do
     ln -s "$REPO_DIR/$f" "$SANDBOX/$f"
 done
 

--- a/tests/setup-sandbox.sh
+++ b/tests/setup-sandbox.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SANDBOX="${TMPDIR:-/tmp}/ralph-smoke-$(date +%Y%m%d-%H%M%S)"
+
+mkdir -p "$SANDBOX"
+
+for f in PROMPT.md ralph.sh ralph-prep.sh ralph-lib.sh RALPH-CC.md; do
+    ln -s "$REPO_DIR/$f" "$SANDBOX/$f"
+done
+
+cp "$REPO_DIR/tests/tasks.json" "$SANDBOX/tasks.json"
+
+cat <<EOF
+Sandbox ready: $SANDBOX
+
+Headless mode:
+  cd $SANDBOX && ./ralph.sh --max-iterations 3
+
+Claude Code mode:
+  cd $SANDBOX && claude
+  then in the session: follow RALPH-CC.md, max-iterations 3
+EOF

--- a/tests/tasks.json
+++ b/tests/tasks.json
@@ -1,0 +1,27 @@
+{
+  "project": "sandbox",
+  "branch": "ralph/smoke-test",
+  "description": "Smoke test fixture for ralph harness",
+  "stories": [
+    {
+      "id": "US-001",
+      "title": "Create hello.txt with greeting",
+      "acceptanceCriteria": [
+        "File hello.txt exists at repo root",
+        "File contains the text 'hello from ralph'"
+      ],
+      "priority": 1,
+      "passes": false
+    },
+    {
+      "id": "US-002",
+      "title": "Append line to hello.txt",
+      "acceptanceCriteria": [
+        "hello.txt contains a second line: 'smoke test passed'",
+        "Original first line is preserved"
+      ],
+      "priority": 2,
+      "passes": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Factor `ralph.sh`'s helper functions into a shared `ralph-lib.sh` so future runners can reuse the same bookkeeping (archive, notebook init, prompt fill, history query).
- Add `RALPH-CC.md` + `ralph-prep.sh`: a drop-in alternative to `./ralph.sh --max-iterations N` that runs entirely inside a live Claude Code chat session, using `Agent()` instead of headless `claude -p`. Per-iteration semantics, `PROMPT.md`, `tasks.json`, and `.lnb/` are identical to the existing flow.
- Add `tests/` sandbox scaffold for smoke-testing both modes.

## Motivation

Closes #7. `claude -p` (headless mode) may be removed or restricted to API-only auth. `ralph.sh` depends on it. This PR provides an equivalent that runs natively inside Claude Code so the workflow survives.

Key design decisions:

- **`PROMPT.md` is untouched.** The existing SIGNAL step (`<promise>DONE</promise>` / `<promise>ALL_DONE</promise>`) works as-is when the subagent's final message gets returned via the `Agent` tool.
- **No orchestrator subagent layer.** The main Claude Code session *is* the orchestrator — it runs the loop, spawns workers, checks promises. The ~50 tokens of subagent narration that leaks into the main session per iteration is acceptable (~1k tokens over 20 iterations).
- **Shared-lib refactor.** `ralph.sh` and `ralph-prep.sh` both source `ralph-lib.sh`, so the two runners stay in sync forever.
- **Stop-on-no-marker.** If a subagent returns without any promise marker, the main session stops and logs a blocker. Small deviation from `ralph.sh` (which only stops on non-zero exit), but the subagent model has no exit code.

## Behavior differences from `ralph.sh`

| Aspect | `ralph.sh` | RALPH-CC.md flow |
|---|---|---|
| Entry point | `./ralph.sh --max-iterations N` | Chat: "follow RALPH-CC.md, max-iterations N" |
| Per-iter agent | `claude -p --permission-mode acceptEdits` | `Agent(subagent_type="general-purpose")` |
| Permission mode | CLI flag | Inherited from main session |
| Intermediate display | stream-json via `format_stream` | Claude Code's native subagent UI |
| Stop on no marker | no | yes |
| Main-session context cost | 0 | ~50 tokens/iter |
| State storage (`tasks.json`, `.lnb/`, `archive/`) | same | same |

## Commits

1. `refactor(ralph): extract helpers into ralph-lib.sh` — pure refactor, -86/+4 in `ralph.sh`, new `ralph-lib.sh`. Also routes diagnostic output in `archive_previous_run` and `ensure_notebook` to stderr so stdout-capturing callers (like `ralph-prep.sh`) stay clean. No behavior change for `ralph.sh`.
2. `feat: add RALPH-CC.md flow for running ralph inside Claude Code` — adds `ralph-prep.sh`, `RALPH-CC.md`, `.gitignore`.
3. `test: add tests/ sandbox scaffold for smoke-testing ralph` — adds `tests/README.md`, `tests/setup-sandbox.sh`, `tests/tasks.json`.

## Test plan

- [x] **`ralph.sh` regression:** `./tests/setup-sandbox.sh && cd <sandbox> && ./ralph.sh --max-iterations 3` — should complete both fixture stories and report `ALL_DONE` within 2 iterations, same as before.
- [x] **New RALPH-CC.md flow:** `./tests/setup-sandbox.sh`, then `cd <sandbox> && claude` in `acceptEdits` mode, then in the session: `follow RALPH-CC.md, max-iterations 3`. Expect `hello.txt` created with both lines, `tasks.json` stories flipped to `passes: true`, `.lnb/` populated, `ALL_DONE` reported.
- [x] **Stdout cleanliness:** `./ralph-prep.sh --iteration 1 > /tmp/prompt.out` (in a sandbox with a fixture `tasks.json`) — `/tmp/prompt.out` should contain only the filled prompt, no `Initialized lab notebook` or other diagnostic noise.
- [ ] **Archive-on-branch-change:** run once, change the `branch` field in `tasks.json`, run again — previous run should be archived under `archive/<date>-<old-branch>/`.

## Out of scope (follow-ups)

- `README.md` update advertising the new mode.
- Additional `.gitignore` entries (`.ralph-last-branch`, `archive/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
