### PR TITLE
feat: install.sh + /ralph-lnb skill for ergonomic invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Two install artifacts:
 
 - `~/.local/bin/ralph` → symlink to the headless runner. Put `~/.local/bin`
   on `$PATH` if it isn't already (`install.sh` warns you if not).
-- `~/.claude/skills/ralph-lnb/SKILL.md` → the `/ralph-lnb` slash command
-  for Claude Code chats.
+- `~/.claude/skills/ralph-lnb/SKILL.md` → the `ralph-lnb` skill. Claude
+  Code exposes user-invocable skills as slash commands, so it appears
+  as `/ralph-lnb` in chat.
 
 After install, the invocations become:
 
@@ -31,7 +32,8 @@ After install, the invocations become:
 `install.sh` is idempotent. Re-run it after moving or re-cloning the
 repo — it rewrites the skill with the new path. Override the bin
 location with `RALPH_BIN_DIR=/usr/local/bin ./install.sh`. Undo with
-`./uninstall.sh`.
+`./uninstall.sh` — if you overrode `RALPH_BIN_DIR` on install, pass
+the same value on uninstall so it can find the symlink to remove.
 
 If you prefer not to install, the absolute-path invocations in the
 Quick Start below still work.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,34 @@ Based on the [Ralph Wiggum technique](https://ghuntley.com/ralph/) with
 structured notebook logging (queryable history, pattern discovery). See also
 [Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents).
 
+## Install
+
+```bash
+git clone https://github.com/carbonscott/ralph-wiggum-lnb ~/codes/ralph-wiggum-lnb
+~/codes/ralph-wiggum-lnb/install.sh
+```
+
+Two install artifacts:
+
+- `~/.local/bin/ralph` → symlink to the headless runner. Put `~/.local/bin`
+  on `$PATH` if it isn't already (`install.sh` warns you if not).
+- `~/.claude/skills/ralph-lnb/SKILL.md` → the `/ralph-lnb` slash command
+  for Claude Code chats.
+
+After install, the invocations become:
+
+- **Headless**: `ralph --max-iterations 3`
+- **Claude Code chat**: `/ralph-lnb max-iterations 3` (restart any
+  running sessions — skills load at session start)
+
+`install.sh` is idempotent. Re-run it after moving or re-cloning the
+repo — it rewrites the skill with the new path. Override the bin
+location with `RALPH_BIN_DIR=/usr/local/bin ./install.sh`. Undo with
+`./uninstall.sh`.
+
+If you prefer not to install, the absolute-path invocations in the
+Quick Start below still work.
+
 ## Quick Start
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -115,8 +115,11 @@ fi
 
 if [[ $install_skill -eq 1 ]]; then
     # Render template: substitute @@RALPH_REPO@@ with the absolute repo path.
-    # Use | as sed delimiter since paths contain / — REPO shouldn't contain |.
-    sed "s|@@RALPH_REPO@@|$REPO|g" "$TEMPLATE" > "$SKILL_TARGET"
+    # Escape \, |, & in $REPO — those are the three characters sed treats
+    # specially in the replacement string. Backslash must go first so the
+    # subsequent substitutions don't double-escape.
+    REPO_ESCAPED=$(printf '%s\n' "$REPO" | sed 's/[\\|&]/\\&/g')
+    sed "s|@@RALPH_REPO@@|$REPO_ESCAPED|g" "$TEMPLATE" > "$SKILL_TARGET"
     echo "Installed: $SKILL_TARGET (rendered with $REPO)"
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install ralph-wiggum-lnb ergonomic entry points:
+#   1. Symlink this repo's cc-headless/ralph.sh into $BIN_DIR (default: ~/.local/bin)
+#      so `ralph` runs from any cwd.
+#   2. Render skill/SKILL.md.template -> ~/.claude/skills/ralph-lnb/SKILL.md
+#      with @@RALPH_REPO@@ substituted, so `/ralph-lnb` works in Claude Code chats.
+#
+# Idempotent: safe to re-run after moving or re-cloning the repo. Pass --force
+# to overwrite install artifacts that don't belong to ralph-wiggum-lnb.
+
+# --- Resolve this script's real location (symlink-safe) ---
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+    DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+REPO="$(cd "$(dirname "$SOURCE")" && pwd)"
+
+# --- Parse args ---
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        --force) FORCE=1 ;;
+        -h|--help)
+            cat <<'EOF'
+Usage: install.sh [--force]
+
+Installs ralph-wiggum-lnb entry points. Run from a fresh git clone:
+
+    git clone <url> ~/codes/ralph-wiggum-lnb
+    ~/codes/ralph-wiggum-lnb/install.sh
+
+Environment variables:
+  RALPH_BIN_DIR   Where to put the `ralph` symlink. Default: ~/.local/bin
+
+Options:
+  --force         Overwrite install artifacts that don't belong to this repo
+  -h, --help      Show this help
+
+Run ./uninstall.sh from the repo to undo.
+EOF
+            exit 0 ;;
+        *) echo "Unknown option: $arg" >&2; exit 2 ;;
+    esac
+done
+
+BIN_DIR="${RALPH_BIN_DIR:-$HOME/.local/bin}"
+SKILL_DIR="$HOME/.claude/skills/ralph-lnb"
+BIN_TARGET="$BIN_DIR/ralph"
+SKILL_TARGET="$SKILL_DIR/SKILL.md"
+TEMPLATE="$REPO/skill/SKILL.md.template"
+MARKER="Managed by ralph-wiggum-lnb install.sh"
+
+# --- Preflight: template must exist ---
+if [[ ! -f "$TEMPLATE" ]]; then
+    echo "Error: template not found at $TEMPLATE" >&2
+    echo "Is this a complete ralph-wiggum-lnb checkout?" >&2
+    exit 1
+fi
+
+# --- Install 1: symlink `ralph` into BIN_DIR ---
+mkdir -p "$BIN_DIR"
+
+install_bin=1
+if [[ -e "$BIN_TARGET" || -L "$BIN_TARGET" ]]; then
+    if [[ -L "$BIN_TARGET" ]]; then
+        existing="$(readlink "$BIN_TARGET")"
+        if [[ "$existing" == "$REPO/cc-headless/ralph.sh" ]]; then
+            echo "Symlink $BIN_TARGET already points at this repo — refreshing."
+        else
+            if [[ $FORCE -eq 1 ]]; then
+                echo "Overwriting $BIN_TARGET (was: $existing)"
+            else
+                echo "Warning: $BIN_TARGET is a symlink to $existing, not this repo." >&2
+                echo "         Skipping. Re-run with --force to overwrite." >&2
+                install_bin=0
+            fi
+        fi
+    else
+        if [[ $FORCE -eq 1 ]]; then
+            echo "Overwriting non-symlink file at $BIN_TARGET"
+        else
+            echo "Warning: $BIN_TARGET exists and is not a symlink." >&2
+            echo "         Skipping. Re-run with --force to overwrite." >&2
+            install_bin=0
+        fi
+    fi
+fi
+
+if [[ $install_bin -eq 1 ]]; then
+    ln -sf "$REPO/cc-headless/ralph.sh" "$BIN_TARGET"
+    echo "Installed: $BIN_TARGET -> $REPO/cc-headless/ralph.sh"
+fi
+
+# --- Install 2: render skill template ---
+mkdir -p "$SKILL_DIR"
+
+install_skill=1
+if [[ -f "$SKILL_TARGET" ]]; then
+    if grep -q "$MARKER" "$SKILL_TARGET"; then
+        echo "Skill $SKILL_TARGET is managed by install.sh — refreshing."
+    else
+        if [[ $FORCE -eq 1 ]]; then
+            echo "Overwriting unmanaged skill at $SKILL_TARGET"
+        else
+            echo "Warning: $SKILL_TARGET exists and is not managed by this installer." >&2
+            echo "         Skipping. Re-run with --force to overwrite." >&2
+            install_skill=0
+        fi
+    fi
+fi
+
+if [[ $install_skill -eq 1 ]]; then
+    # Render template: substitute @@RALPH_REPO@@ with the absolute repo path.
+    # Use | as sed delimiter since paths contain / — REPO shouldn't contain |.
+    sed "s|@@RALPH_REPO@@|$REPO|g" "$TEMPLATE" > "$SKILL_TARGET"
+    echo "Installed: $SKILL_TARGET (rendered with $REPO)"
+fi
+
+# --- PATH check (informational only) ---
+case ":$PATH:" in
+    *":$BIN_DIR:"*)
+        path_on=1 ;;
+    *)
+        path_on=0 ;;
+esac
+
+# --- Post-install summary ---
+cat <<EOF
+
+Done. Quick usage:
+  ralph --max-iterations 3                 # headless mode
+  /ralph-lnb max-iterations 3              # in a Claude Code chat
+
+EOF
+
+if [[ $path_on -eq 0 ]]; then
+    cat <<EOF
+Note: $BIN_DIR is not on your \$PATH. Add this to your shell rc:
+  export PATH="$BIN_DIR:\$PATH"
+
+EOF
+fi
+
+cat <<EOF
+Note: Claude Code caches its skill list per session. Restart any
+running chat sessions to pick up /ralph-lnb.
+EOF

--- a/skill/SKILL.md.template
+++ b/skill/SKILL.md.template
@@ -1,0 +1,129 @@
+---
+name: ralph-lnb
+description: "Run the Ralph Wiggum autonomous code loop inside a Claude Code session. Use when the user types /ralph-lnb, or says 'run ralph', 'start the ralph loop', 'keep iterating on the tasks', or asks to work through tasks.json story-by-story. Each iteration spawns a fresh subagent to complete one story and logs progress to the lab notebook."
+user-invocable: true
+argument-hint: "[max-iterations N] [task-file FILE]"
+---
+
+<!-- Managed by ralph-wiggum-lnb install.sh — do not edit by hand. Re-run ./install.sh from the repo to regenerate. -->
+
+# Ralph Loop — Claude Code Session Skill
+
+This skill runs the ralph loop (one story per iteration, fresh subagent each time, logs to `.lnb/`) using the `Agent()` subagent tool inside the current Claude Code chat. It is the skill-based equivalent of `@@RALPH_REPO@@/cc-headless/ralph.sh`, which spawns `claude -p` per iteration instead.
+
+The ralph repo this skill was generated from lives at:
+
+    @@RALPH_REPO@@
+
+If that path is stale (you moved or re-cloned the repo), re-run `./install.sh` from the new location to regenerate this file.
+
+## Parse arguments
+
+Parse `$ARGUMENTS` as a whitespace-separated list of `key value` pairs. Supported keys:
+
+| Key | Default | Notes |
+|---|---|---|
+| `max-iterations` | `10` | Safety cap on the loop |
+| `task-file` | `tasks.json` | Path to the task file (relative to cwd) |
+
+Everything else gets ignored. Examples of valid argument strings:
+
+- *(empty)* — use all defaults
+- `max-iterations 5`
+- `max-iterations 3 task-file sprint.json`
+
+## Prerequisites (verify before starting)
+
+1. The current Claude Code session must be in `acceptEdits` permission mode (or the user must approve each subagent tool call manually). Subagents inherit the parent session's permission mode. This replaces `cc-headless/ralph.sh`'s `--permission-mode acceptEdits` flag.
+2. `<task-file>` must exist in the current working directory and contain stories in the format described at `@@RALPH_REPO@@/shared/tasks.json.example`.
+3. A `PROMPT.md` must exist in the current working directory. If it doesn't, tell the user:
+
+   > No `PROMPT.md` in this directory. Copy it from the repo first:
+   > ```
+   > cp @@RALPH_REPO@@/shared/PROMPT.md .
+   > ```
+
+   Wait for them to do that (or confirm they want you to do it), then proceed.
+4. `jq` and `lab-notebook` must be on `$PATH`. If missing, tell the user and stop.
+
+## Procedure
+
+When invoked, the main session (you) must do the following. Do not deviate, do not add steps, do not narrate beyond the minimum specified.
+
+### Setup
+
+1. Parse `max-iterations` and `task-file` from `$ARGUMENTS`. Apply the defaults above for anything unspecified.
+2. Derive the notebook context once, so every subsequent log call uses the same value:
+
+   ```
+   Bash("jq -r '.branch // .project // \"ralph-dev\"' <task-file>")
+   ```
+
+   Capture stdout into `<context>`. This mirrors how `ralph-prep.sh` derives it, so both runners agree on the context slug.
+3. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X, context=<context>"`. One line, nothing more.
+
+### Loop
+
+For `i` in `1..max-iterations`:
+
+1. **Build the prompt.** Call:
+
+   ```
+   Bash("@@RALPH_REPO@@/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>")
+   ```
+
+   Pass the same `N` you parsed in Setup so the start log entry records the cap alongside the iteration number (matches `cc-headless/ralph.sh`'s log format). Capture the tool result's stdout. This is the filled prompt. Do not read, quote, or summarize it — just hold it for the next step.
+
+2. **Spawn the worker.** Call:
+
+   ```
+   Agent(
+       subagent_type="general-purpose",
+       description="ralph iteration i",
+       prompt=<stdout from step 1>
+   )
+   ```
+
+   The subagent will complete one story and return a final message ending with either `<promise>DONE</promise>` or `<promise>ALL_DONE</promise>`.
+
+3. **Check the return.** Inspect the subagent's final message. **Check `ALL_DONE` first — `<promise>ALL_DONE</promise>` contains `<promise>DONE</promise>` as a substring, so the order is load-bearing.** (Same reason `cc-headless/ralph.sh`'s grep checks `ALL_DONE` before `DONE`.)
+
+   - Contains `<promise>ALL_DONE</promise>`:
+     - Call `Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook emit --context <context> --type done --tags ralph-harness 'ralph-lnb: all stories complete at iteration i'")` using the `<context>` derived in Setup step 2.
+     - Break the loop. Go to "Post-loop".
+   - Contains `<promise>DONE</promise>`:
+     - Say exactly: `"iteration i: DONE, continuing"`. One line.
+     - Continue to next iteration.
+   - Neither marker:
+     - Call `Bash(...)` to log a blocker entry (same shape as above but `--type blocker` and `"ralph-lnb: iteration i ended without promise"`).
+     - Break the loop. Go to "Post-loop".
+
+### Post-loop
+
+1. If the loop ended on `ALL_DONE`, optionally query the notebook for a summary, using the `<context>` derived in Setup step 2:
+
+   ```
+   Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook sql \"SELECT ts, type, issue, substr(content,1,200) FROM entries WHERE context='<context>' AND type IN ('start','done','impl','blocker') ORDER BY ts\"")
+   ```
+
+   Report a 3-5 sentence summary to the user covering what each story accomplished.
+
+2. If the loop ended on `max-iterations`, report: `"Hit iteration cap (N). Stopped. Check .lnb/ for progress."`
+
+3. If the loop ended on a missing marker, report: `"Iteration i returned without a promise marker. Stopped. Check .lnb/ for the blocker entry and the subagent's final message."`
+
+## Stop conditions (summary)
+
+- `<promise>ALL_DONE</promise>` seen → success.
+- `max-iterations` reached → capped.
+- No promise marker in a subagent return → blocker.
+
+## Context budgeting
+
+Each iteration adds ~50 tokens (the subagent's final narration plus the promise marker) to the main session's context. A 20-iteration run is roughly 1k tokens — acceptable. Keep your own between-iteration narration to one short line (`"iteration i: DONE, continuing"`). Do not summarize subagent output, do not re-read `tasks.json` yourself (`ralph-prep.sh` already does it every iteration), do not print anything the user doesn't need.
+
+## Relationship to the headless runner
+
+The headless runner `@@RALPH_REPO@@/cc-headless/ralph.sh` uses the same `ralph-prep.sh`, `shared/ralph-lib.sh`, `shared/PROMPT.md`, `tasks.json`, and `.lnb/` state. A change to `shared/ralph-lib.sh` affects both runners. The only difference is who spawns the per-iteration agent: `claude -p` in headless, `Agent()` in this skill.
+
+$ARGUMENTS

--- a/tests/README.md
+++ b/tests/README.md
@@ -10,10 +10,15 @@ Exercises both modes so you can verify `cc/RALPH-CC.md` and
 - `tasks.json` — 2-story fixture (create `hello.txt`, append a line)
 - `setup-sandbox.sh` — scaffolds a timestamped sandbox under `$TMPDIR`
 
+Prerequisite: run `../install.sh` once from the repo so `ralph` is on
+`$PATH` and `/ralph-lnb` is registered as a Claude Code skill. If you
+prefer not to install, the sandbox-setup script also prints
+absolute-path fallbacks you can use instead.
+
 ## Running in Claude Code (non-headless)
 
 1. From the repo root: `./tests/setup-sandbox.sh`. Note the sandbox
-   path and the `cc/RALPH-CC.md` absolute path it prints.
+   path it prints.
 2. Open a new session in the sandbox:
    ```
    cd /tmp/ralph-smoke-YYYYMMDD-HHMMSS && claude
@@ -22,8 +27,9 @@ Exercises both modes so you can verify `cc/RALPH-CC.md` and
    `/permissions`). Subagents inherit the main session's permission
    mode, so this replaces `cc-headless/ralph.sh`'s
    `--permission-mode acceptEdits` flag.
-4. In the session: `follow <REPO_DIR>/cc/RALPH-CC.md, max-iterations 3`
-   (the sandbox-setup script prints the exact line to use).
+4. In the session: `/ralph-lnb max-iterations 3` (the sandbox-setup
+   script prints the exact line to use, including the no-install
+   fallback if you haven't run `../install.sh` yet).
 5. Expected: Claude creates `hello.txt` with the two expected lines
    and reports `ALL_DONE` within 2 iterations.
 6. Verify:
@@ -36,12 +42,12 @@ Exercises both modes so you can verify `cc/RALPH-CC.md` and
 ## Running headless
 
 ```
-cd /tmp/ralph-smoke-YYYYMMDD-HHMMSS && <REPO_DIR>/cc-headless/ralph.sh --max-iterations 3
+cd /tmp/ralph-smoke-YYYYMMDD-HHMMSS && ralph --max-iterations 3
 ```
 
-The sandbox-setup script prints the exact command with `<REPO_DIR>`
-resolved. See `../cc/RALPH-CC.md` and `../cc-headless/ralph.sh --help`
-for details on each mode.
+The sandbox-setup script prints the exact command (assuming you've
+run `../install.sh` from the repo once). See `../cc/RALPH-CC.md` and
+`../cc-headless/ralph.sh --help` for details on each mode.
 
 ## Cleanup
 

--- a/tests/setup-sandbox.sh
+++ b/tests/setup-sandbox.sh
@@ -16,9 +16,14 @@ cat <<EOF
 Sandbox ready: $SANDBOX
 
 Headless mode:
-  cd $SANDBOX && $REPO_DIR/cc-headless/ralph.sh --max-iterations 3
+  cd $SANDBOX && ralph --max-iterations 3
 
 Claude Code mode:
   cd $SANDBOX && claude
-  then in the session: follow $REPO_DIR/cc/RALPH-CC.md, max-iterations 3
+  then in the session: /ralph-lnb max-iterations 3
+
+Not installed yet? Run $REPO_DIR/install.sh first, or use the
+absolute-path fallback:
+  $REPO_DIR/cc-headless/ralph.sh --max-iterations 3
+  follow $REPO_DIR/cc/RALPH-CC.md, max-iterations 3
 EOF

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Undo what install.sh did. Only removes artifacts that clearly belong to
+# ralph-wiggum-lnb — refuses to touch anything unfamiliar.
+
+# --- Resolve this script's real location (symlink-safe) ---
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+    DIR="$(cd "$(dirname "$SOURCE")" && pwd)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+REPO="$(cd "$(dirname "$SOURCE")" && pwd)"
+
+BIN_DIR="${RALPH_BIN_DIR:-$HOME/.local/bin}"
+SKILL_DIR="$HOME/.claude/skills/ralph-lnb"
+BIN_TARGET="$BIN_DIR/ralph"
+SKILL_TARGET="$SKILL_DIR/SKILL.md"
+MARKER="Managed by ralph-wiggum-lnb install.sh"
+
+removed_any=0
+
+# --- Uninstall 1: remove the ralph symlink if it points at this repo ---
+if [[ -L "$BIN_TARGET" ]]; then
+    existing="$(readlink "$BIN_TARGET")"
+    if [[ "$existing" == "$REPO/cc-headless/ralph.sh" ]]; then
+        rm -f "$BIN_TARGET"
+        echo "Removed: $BIN_TARGET"
+        removed_any=1
+    else
+        echo "Leaving $BIN_TARGET alone (points at $existing, not this repo)."
+    fi
+elif [[ -e "$BIN_TARGET" ]]; then
+    echo "Leaving $BIN_TARGET alone (not a symlink)."
+fi
+
+# --- Uninstall 2: remove the skill file if managed ---
+if [[ -f "$SKILL_TARGET" ]]; then
+    if grep -q "$MARKER" "$SKILL_TARGET"; then
+        rm -f "$SKILL_TARGET"
+        echo "Removed: $SKILL_TARGET"
+        removed_any=1
+        # Clean up the parent dir if it's now empty.
+        if [[ -d "$SKILL_DIR" ]] && [[ -z "$(ls -A "$SKILL_DIR")" ]]; then
+            rmdir "$SKILL_DIR"
+            echo "Removed empty dir: $SKILL_DIR"
+        fi
+    else
+        echo "Leaving $SKILL_TARGET alone (not managed by this installer)."
+    fi
+fi
+
+if [[ $removed_any -eq 0 ]]; then
+    echo "Nothing to remove."
+fi


### PR DESCRIPTION
Closes #12.

**Stacked on #11** (`refactor/cc-headless-layout`) — the base of this PR is `refactor/cc-headless-layout`, not `master`. GitHub will auto-rebase to `master` when #11 merges.

## Summary

- **`install.sh`**: symlink-safe, idempotent installer that creates two artifacts and nothing else:
  - `~/.local/bin/ralph` → symlink to `cc-headless/ralph.sh`
  - `~/.claude/skills/ralph-lnb/SKILL.md` → rendered from `skill/SKILL.md.template` with the absolute repo path baked in
- **`uninstall.sh`**: mirror; only touches artifacts marked as managed.
- **`skill/SKILL.md.template`**: the `/ralph-lnb` skill body. Parallel to `cc/RALPH-CC.md` rather than templated from it, because the two serve different audiences (Claude in a skill trigger vs. a human reader).
- **README**: new Install section above Quick Start. Absolute-path invocations stay documented as the no-install fallback.

## Zero changes to existing runtime

No edits to `cc-headless/ralph.sh`, `cc/ralph-prep.sh`, `cc/RALPH-CC.md`, `shared/*`, or `tests/*`. Users who prefer not to install still use the same absolute-path invocations from PR #11.

## Design notes

- **Skills, not slash commands.** Anthropic merged slash commands into skills in January 2026. A skill with `name: ralph-lnb` auto-registers as `/ralph-lnb`. Ships with `user-invocable: true` + `argument-hint` frontmatter fields.
- **Name `/ralph-lnb`**, not `/ralph` — avoids collision with the common short name and identifies this lab-notebook-integrated variant.
- **Safety.** `install.sh` refuses to overwrite non-symlink files at the bin target or skill files without the `Managed by ralph-wiggum-lnb install.sh` marker, unless `--force` is passed. `uninstall.sh` has the same guardrails in reverse.
- **Idempotence.** Re-running `install.sh` recognizes its own artifacts and refreshes them. Re-running after moving the repo is the intended way to re-point paths at the new location.
- **Path resolution.** `install.sh` uses the same `BASH_SOURCE`-walking pattern that commit `791a045` added to the runners, so it works correctly when called via a symlink.

## Test plan

Already executed locally. Listed here for reviewer repro.

### 1. Fresh install (clean state)
```bash
rm -f ~/.local/bin/ralph
rm -rf ~/.claude/skills/ralph-lnb
./install.sh
```
- [x] `readlink ~/.local/bin/ralph` → `$REPO/cc-headless/ralph.sh`
- [x] `~/.claude/skills/ralph-lnb/SKILL.md` exists
- [x] `grep -c '@@RALPH_REPO@@' ~/.claude/skills/ralph-lnb/SKILL.md` → 0
- [x] `grep -c "$REPO" ~/.claude/skills/ralph-lnb/SKILL.md` → 6 (all path references substituted)
- [x] `grep -q 'Managed by ralph-wiggum-lnb install.sh' ~/.claude/skills/ralph-lnb/SKILL.md` → present (marker for uninstall detection)
- [x] `ralph --help` works from the symlink

### 2. Idempotence
```bash
./install.sh  # second run
```
- [x] No errors. Refresh-in-place messaging. Both artifacts unchanged.

### 3. Repo-move simulation (without `--force`)
```bash
cp -R $REPO $MOVED
$MOVED/install.sh
```
- [x] Bin symlink **refused** because it points at the original repo (not this one) — safety check triggers.
- [x] Skill was managed, so it gets refreshed to point at `$MOVED`.

### 4. Repo-move simulation (with `--force`)
```bash
$MOVED/install.sh --force
```
- [x] `Overwriting /Users/.../ralph (was: <old-path>)` — explicit "what changed" message.
- [x] Both artifacts now point at `$MOVED`.

### 5. Non-symlink safety
```bash
touch ~/.local/bin/ralph
./install.sh          # should warn and skip
./install.sh --force  # should overwrite with "Overwriting non-symlink file"
```
- [x] Without `--force`: bin skipped with warning, skill still installed (independent paths).
- [x] With `--force`: bin overwritten with clear message.

### 6. Uninstall
```bash
./uninstall.sh
```
- [x] Both artifacts removed. Empty `ralph-lnb/` dir cleaned up.

### 7. Re-uninstall (no-op)
```bash
./uninstall.sh
```
- [x] Prints `"Nothing to remove."`

### 8. Syntax
- [x] `bash -n install.sh uninstall.sh` passes.

### 9. Manual verification
- [ ] Reviewer: restart Claude Code, confirm `/ralph-lnb` appears in the slash-command autocomplete. Skills are cached per session, so newly installed skills require a session restart to show up reliably.

## Out of scope

- No refactor of `cc/RALPH-CC.md` to dedup with the skill template. Parallel files, diff-reviewable.
- No bash tab completion for `ralph`.
- No `--purge` flag in uninstall (user data like `archive/` is never touched).
- No Homebrew/apt packaging. Git-clone-and-go is the shipping model.
