### PR TITLE
feat(runners): default --prompt to shared/PROMPT.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,22 @@ location with `RALPH_BIN_DIR=/usr/local/bin ./install.sh`. Undo with
 `./uninstall.sh` — if you overrode `RALPH_BIN_DIR` on install, pass
 the same value on uninstall so it can find the symlink to remove.
 
-If you prefer not to install, the absolute-path invocations in the
-Quick Start below still work.
+If you prefer not to install, you can still run the scripts by
+absolute path: `~/codes/ralph-wiggum-lnb/cc-headless/ralph.sh` for
+headless mode, or `follow ~/codes/ralph-wiggum-lnb/cc/RALPH-CC.md` in
+a Claude Code session.
 
 ## Quick Start
 
 ```bash
 # In your project directory:
-cp ~/codes/ralph-wiggum-lnb/shared/PROMPT.md .
 cp ~/codes/ralph-wiggum-lnb/shared/tasks.json.example tasks.json
 # Edit tasks.json with your stories
 ```
+
+The runner uses `shared/PROMPT.md` from the installed repo by default.
+Copy it locally and pass `--prompt ./PROMPT.md` only if you want to
+customize the template.
 
 The runner auto-initializes `.lnb/` with the coding schema on the first
 iteration — no manual `lab-notebook init` needed.
@@ -55,19 +60,22 @@ Then pick one runner:
 **Headless** (uses `claude -p`):
 
 ```bash
-~/codes/ralph-wiggum-lnb/cc-headless/ralph.sh --max-iterations 5
+ralph --max-iterations 5
 ```
 
 **Inside a Claude Code session** (uses the `Agent()` subagent tool — no `-p` needed):
 
 Start Claude Code in `acceptEdits` mode, then in the session:
 
-> follow ~/codes/ralph-wiggum-lnb/cc/RALPH-CC.md, max-iterations 5
+> /ralph-lnb max-iterations 5
 
-No extra files need to live in your project dir — `PROMPT.md` +
-`tasks.json` is the entire footprint. Helper scripts, the shared lib,
-and the notebook schema all stay in the repo and are invoked or sourced
-by absolute path.
+(Restart any running Claude Code sessions after install — skills load
+at session start.)
+
+`tasks.json` is the entire footprint in your project dir. The prompt
+template, shared lib, helper scripts, and notebook schema all stay in
+the repo and are invoked or sourced by `ralph` / `/ralph-lnb` (or by
+absolute path if you skipped install).
 
 ## How It Works
 
@@ -179,20 +187,21 @@ LAB_NOTEBOOK_DIR=.lnb lab-notebook sql \
   "SELECT content FROM entries WHERE type='pattern' ORDER BY ts"
 ```
 
-## `cc-headless/ralph.sh` options
+## Headless runner options (ralph)
 
 ```
 --max-iterations N      Safety cap (default: 10)
---prompt FILE           Prompt template (default: PROMPT.md)
+--prompt FILE           Custom prompt template (default: repo's shared/PROMPT.md)
 --task-file FILE        Task file (default: tasks.json)
 --notebook DIR          Notebook directory (default: .lnb)
 --context SLUG          Notebook context (default: from branch)
 --archive-dir DIR       Archive directory (default: archive/)
 ```
 
-For the Claude Code session runner, `max-iterations`, `task-file`, and
-related parameters are passed inline when invoking the driver doc — see
-`cc/RALPH-CC.md`.
+For the Claude Code session runner, invoke it as `/ralph-lnb
+max-iterations N` (with `task-file` and other parameters passed
+inline). See `cc/RALPH-CC.md` for the underlying driver doc and
+stop-condition semantics.
 
 ## Archive
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,10 @@ cp ~/codes/ralph-wiggum-lnb/shared/tasks.json.example tasks.json
 
 The runner uses `shared/PROMPT.md` from the installed repo by default.
 Copy it locally and pass `--prompt ./PROMPT.md` only if you want to
-customize the template.
+customize the template. **Upgrading from an older checkout?** A stale
+`./PROMPT.md` in your project dir is no longer auto-picked up — delete
+it if you never customized it, or pass `--prompt ./PROMPT.md`
+explicitly if you did.
 
 The runner auto-initializes `.lnb/` with the coding schema on the first
 iteration — no manual `lab-notebook init` needed.

--- a/cc-headless/ralph.sh
+++ b/cc-headless/ralph.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # --- Defaults ---
 MAX_ITERATIONS=10
-PROMPT_FILE="PROMPT.md"
+PROMPT_FILE=""
 TASK_FILE="tasks.json"
 NOTEBOOK_DIR=".lnb"
 CONTEXT=""
@@ -32,7 +32,7 @@ file (tasks.json) and a lab-notebook.
 
 Options:
   --max-iterations N      Safety cap (default: 10)
-  --prompt FILE           Prompt template (default: PROMPT.md)
+  --prompt FILE           Custom prompt template (default: repo's shared/PROMPT.md)
   --task-file FILE        Task file with stories (default: tasks.json)
   --notebook DIR          Lab-notebook directory (default: .lnb)
   --context SLUG          Notebook context (default: derived from branch)
@@ -66,10 +66,14 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Default to the repo's shared template if --prompt wasn't passed.
+if [[ -z "$PROMPT_FILE" ]]; then
+    PROMPT_FILE="$SHARED_DIR/PROMPT.md"
+fi
+
 # --- Validate ---
 if [[ ! -f "$PROMPT_FILE" ]]; then
     echo "Error: Prompt file '$PROMPT_FILE' not found." >&2
-    echo "Copy the template: cp $SHARED_DIR/PROMPT.md ." >&2
     exit 1
 fi
 
@@ -134,6 +138,7 @@ echo "Project:    ${PROJECT:-<none>}"
 echo "Branch:     ${BRANCH:-<none>}"
 echo "Context:    $CONTEXT"
 echo "Task file:  $TASK_FILE"
+echo "Prompt:     $PROMPT_FILE"
 echo "Notebook:   $NOTEBOOK_DIR"
 echo "Max iter:   $MAX_ITERATIONS"
 echo "============="

--- a/cc/RALPH-CC.md
+++ b/cc/RALPH-CC.md
@@ -5,23 +5,29 @@ designed to run entirely inside a live Claude Code chat session using
 the `Agent()` subagent tool instead of headless `claude -p`. Use this
 when `-p` mode is unavailable or restricted.
 
-Same `PROMPT.md`, same `tasks.json`, same `.lnb/` notebook, same
-`archive/` directory, same per-iteration semantics. The only thing that
-changes is who spawns the per-iteration agent.
+Same prompt template, same `tasks.json`, same `.lnb/` notebook, same
+`archive/` directory, same per-iteration semantics. The only thing
+that changes is who spawns the per-iteration agent.
 
 ## How to invoke
 
 In a Claude Code chat, type one of:
 
-> follow ~/codes/ralph-wiggum-lnb/cc/RALPH-CC.md, max-iterations 10
+> /ralph-lnb max-iterations 10
 
-> follow ~/codes/ralph-wiggum-lnb/cc/RALPH-CC.md, max-iterations 5, task-file tasks.json
+> /ralph-lnb max-iterations 5, task-file tasks.json
+
+> /ralph-lnb max-iterations 5, prompt ./custom-prompt.md
+
+If you skipped `install.sh`, the long form still works:
+
+> follow ~/codes/ralph-wiggum-lnb/cc/RALPH-CC.md, max-iterations 10
 
 Defaults when unspecified:
 
 - `max-iterations` = 10
 - `task-file` = `tasks.json`
-- `prompt` = `PROMPT.md`
+- `prompt` = the installed repo's `shared/PROMPT.md`
 - `notebook` = `.lnb`
 
 ## Prerequisites
@@ -30,13 +36,12 @@ Defaults when unspecified:
    (or you must approve each subagent tool call manually). Subagents
    inherit the parent session's permission mode. This replaces
    `ralph.sh`'s `--permission-mode acceptEdits` flag.
-2. `PROMPT.md` and `tasks.json` must exist in the current directory.
-   Copy them from the repo: `cp ~/codes/ralph-wiggum-lnb/shared/PROMPT.md .`
-   and `cp ~/codes/ralph-wiggum-lnb/shared/tasks.json.example tasks.json`,
-   then edit `tasks.json` to describe your stories. Nothing else needs
-   to live in the project dir — `ralph-prep.sh`, `ralph-lib.sh`, and
-   `coding-dev.yaml` all stay in the repo and are invoked/sourced by
-   absolute path.
+2. `tasks.json` must exist in the current directory. Copy the starter
+   and edit it: `cp ~/codes/ralph-wiggum-lnb/shared/tasks.json.example tasks.json`,
+   then describe your stories. Nothing else needs to live in the
+   project dir — the prompt template, `ralph-prep.sh`, `ralph-lib.sh`,
+   and `coding-dev.yaml` all stay in the repo and are invoked/sourced
+   by absolute path.
 3. `jq` and `lab-notebook` must be on `$PATH` (same as for `ralph.sh`).
 
 ## Procedure for the main Claude Code session
@@ -47,8 +52,10 @@ minimum specified.
 
 ### Setup
 
-1. Parse `max-iterations` and `task-file` from the user's message.
-   Apply defaults for anything unspecified.
+1. Parse `max-iterations`, `task-file`, and `prompt` from the user's
+   message. Apply defaults for anything unspecified. `prompt` is
+   optional — if the user did not supply it, leave it unset and omit
+   `--prompt` from the `ralph-prep.sh` call in Loop step 1.
 2. Derive the notebook context once, so every subsequent log call uses
    the same value:
 
@@ -68,8 +75,12 @@ For `i` in `1..max-iterations`:
 1. **Build the prompt.** Call:
 
    ```
-   Bash("$HOME/codes/ralph-wiggum-lnb/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>")
+   Bash("$HOME/codes/ralph-wiggum-lnb/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>[ --prompt <prompt>]")
    ```
+
+   Append `--prompt <prompt>` only if the user supplied one in Setup
+   step 1; otherwise omit the flag so `ralph-prep.sh` uses its own
+   default (`shared/PROMPT.md`).
 
    Pass the same `N` you parsed in Setup so the start log entry records
    the cap alongside the iteration number (matches `ralph.sh`'s log
@@ -150,7 +161,7 @@ the user doesn't need.
 
 | Aspect | `ralph.sh` | This flow |
 |---|---|---|
-| Entry | terminal: `~/codes/ralph-wiggum-lnb/cc-headless/ralph.sh --max-iterations N` | chat: "follow ~/codes/ralph-wiggum-lnb/cc/RALPH-CC.md, max-iterations N" |
+| Entry | terminal: `ralph --max-iterations N` | chat: `/ralph-lnb max-iterations N` |
 | Per-iter agent | `claude -p --permission-mode acceptEdits` | `Agent(subagent_type="general-purpose")` |
 | Permission mode | CLI flag | inherited from main session |
 | Intermediate display | stream-json via `format_stream` | native Claude Code subagent UI |

--- a/cc/RALPH-CC.md
+++ b/cc/RALPH-CC.md
@@ -65,8 +65,11 @@ minimum specified.
 
    Capture stdout into `<context>`. This mirrors how `ralph-prep.sh`
    derives it, so both runners agree on the context slug.
-3. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X, context=<context>"`.
-   One line, nothing more.
+3. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X, prompt=P, context=<context>"`.
+   One line, nothing more. Use the user-supplied prompt path for `P`
+   if they passed one; otherwise use the literal string
+   `shared/PROMPT.md` so readers can tell at a glance which template
+   is in play.
 
 ### Loop
 

--- a/cc/ralph-prep.sh
+++ b/cc/ralph-prep.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # it and pass it to Agent(). Diagnostics go to stderr.
 
 # --- Defaults ---
-PROMPT_FILE="PROMPT.md"
+PROMPT_FILE=""
 TASK_FILE="tasks.json"
 NOTEBOOK_DIR=".lnb"
 CONTEXT=""
@@ -36,7 +36,7 @@ to be invoked by a Claude Code session that then passes the stdout to
 the Agent() tool — see RALPH-CC.md.
 
 Options:
-  --prompt FILE           Prompt template (default: PROMPT.md)
+  --prompt FILE           Custom prompt template (default: repo's shared/PROMPT.md)
   --task-file FILE        Task file with stories (default: tasks.json)
   --notebook DIR          Lab-notebook directory (default: .lnb)
   --context SLUG          Notebook context (default: derived from branch)
@@ -67,10 +67,14 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Default to the repo's shared template if --prompt wasn't passed.
+if [[ -z "$PROMPT_FILE" ]]; then
+    PROMPT_FILE="$SHARED_DIR/PROMPT.md"
+fi
+
 # --- Validate ---
 if [[ ! -f "$PROMPT_FILE" ]]; then
     echo "Error: Prompt file '$PROMPT_FILE' not found." >&2
-    echo "Copy the template: cp $SHARED_DIR/PROMPT.md ." >&2
     exit 1
 fi
 

--- a/skill/SKILL.md.template
+++ b/skill/SKILL.md.template
@@ -2,7 +2,7 @@
 name: ralph-lnb
 description: "Run the Ralph Wiggum autonomous code loop inside a Claude Code session. Use when the user types /ralph-lnb, or says 'run ralph', 'start the ralph loop', 'keep iterating on the tasks', or asks to work through tasks.json story-by-story. Each iteration spawns a fresh subagent to complete one story and logs progress to the lab notebook."
 user-invocable: true
-argument-hint: "[max-iterations N] [task-file FILE]"
+argument-hint: "[max-iterations N] [task-file FILE] [prompt FILE]"
 ---
 
 <!-- Managed by ralph-wiggum-lnb install.sh — do not edit by hand. Re-run ./install.sh from the repo to regenerate. -->
@@ -25,25 +25,25 @@ Parse `$ARGUMENTS` as a whitespace-separated list of `key value` pairs. Supporte
 |---|---|---|
 | `max-iterations` | `10` | Safety cap on the loop |
 | `task-file` | `tasks.json` | Path to the task file (relative to cwd) |
+| `prompt` | `@@RALPH_REPO@@/shared/PROMPT.md` | Custom prompt template. Omit to use the repo's shared template. |
 
 Everything else gets ignored. Examples of valid argument strings:
 
 - *(empty)* — use all defaults
 - `max-iterations 5`
 - `max-iterations 3 task-file sprint.json`
+- `max-iterations 5 prompt ./custom-prompt.md`
 
 ## Prerequisites (verify before starting)
 
 1. The current Claude Code session must be in `acceptEdits` permission mode (or the user must approve each subagent tool call manually). Subagents inherit the parent session's permission mode. This replaces `cc-headless/ralph.sh`'s `--permission-mode acceptEdits` flag.
 2. `<task-file>` must exist in the current working directory and contain stories in the format described at `@@RALPH_REPO@@/shared/tasks.json.example`.
-3. A `PROMPT.md` must exist in the current working directory. If it doesn't, tell the user:
-
-   > No `PROMPT.md` in this directory. Copy it from the repo first:
-   > ```
-   > cp @@RALPH_REPO@@/shared/PROMPT.md .
-   > ```
-
-   Wait for them to do that (or confirm they want you to do it), then proceed.
+3. The prompt template. By default, `ralph-prep.sh` loads
+   `@@RALPH_REPO@@/shared/PROMPT.md` — the user does not need to copy
+   anything. If the user passed a `prompt FILE` argument, forward that
+   path to `ralph-prep.sh` on every iteration (see Loop step 1). Do
+   not pre-check the file — `ralph-prep.sh` validates it on iteration
+   1 and errors cleanly if missing.
 4. `jq` and `lab-notebook` must be on `$PATH`. If missing, tell the user and stop.
 
 ## Procedure
@@ -52,7 +52,7 @@ When invoked, the main session (you) must do the following. Do not deviate, do n
 
 ### Setup
 
-1. Parse `max-iterations` and `task-file` from `$ARGUMENTS`. Apply the defaults above for anything unspecified.
+1. Parse `max-iterations`, `task-file`, and `prompt` from `$ARGUMENTS`. Apply the defaults above for anything unspecified. `prompt` is optional — if the user did not supply it, leave the variable unset and omit `--prompt` from the `ralph-prep.sh` call in Loop step 1.
 2. Derive the notebook context once, so every subsequent log call uses the same value:
 
    ```
@@ -69,8 +69,10 @@ For `i` in `1..max-iterations`:
 1. **Build the prompt.** Call:
 
    ```
-   Bash("@@RALPH_REPO@@/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>")
+   Bash("@@RALPH_REPO@@/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>[ --prompt <prompt>]")
    ```
+
+   Append `--prompt <prompt>` only if the user supplied one in Setup step 1; otherwise omit the flag so `ralph-prep.sh` uses its own default (`shared/PROMPT.md`).
 
    Pass the same `N` you parsed in Setup so the start log entry records the cap alongside the iteration number (matches `cc-headless/ralph.sh`'s log format). Capture the tool result's stdout. This is the filled prompt. Do not read, quote, or summarize it — just hold it for the next step.
 

--- a/skill/SKILL.md.template
+++ b/skill/SKILL.md.template
@@ -60,7 +60,7 @@ When invoked, the main session (you) must do the following. Do not deviate, do n
    ```
 
    Capture stdout into `<context>`. This mirrors how `ralph-prep.sh` derives it, so both runners agree on the context slug.
-3. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X, context=<context>"`. One line, nothing more.
+3. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X, prompt=P, context=<context>"`. One line, nothing more. Use the user-supplied prompt path for `P` if they passed one; otherwise use the literal string `shared/PROMPT.md` so readers can tell at a glance which template is in play.
 
 ### Loop
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -61,10 +61,12 @@ Sandboxes are timestamped, so old runs are never overwritten.
 
 - Needs `jq` and `lab-notebook` on `$PATH` (same prerequisites as
   ralph itself).
-- The sandbox symlinks `PROMPT.md` from `shared/` and runs scripts
-  live from the repo by absolute path, so uncommitted changes to
-  `shared/ralph-lib.sh` / `shared/PROMPT.md` / etc. affect the test.
-  This is by design — smoke tests validate the current source tree.
+- The sandbox only contains `tasks.json`. The runners pick up
+  `shared/PROMPT.md` from the repo automatically, and all helper
+  scripts are invoked live from the repo by absolute path — so
+  uncommitted changes to `shared/PROMPT.md`, `shared/ralph-lib.sh`,
+  etc. still affect the test. This is by design: smoke tests validate
+  the current source tree.
 - The fixture's `branch: "ralph/smoke-test"` is just a label used for
   the notebook context and prompt substitution. Ralph does not run
   `git checkout`.

--- a/tests/setup-sandbox.sh
+++ b/tests/setup-sandbox.sh
@@ -6,10 +6,9 @@ SANDBOX="${TMPDIR:-/tmp}/ralph-smoke-$(date +%Y%m%d-%H%M%S)"
 
 mkdir -p "$SANDBOX"
 
-# The sandbox mimics a user's project dir: only PROMPT.md + tasks.json.
-# Runners are invoked by absolute path from $REPO_DIR, exercising the
-# zero-copy invocation model that cc-headless and cc modes both use.
-ln -s "$REPO_DIR/shared/PROMPT.md" "$SANDBOX/PROMPT.md"
+# The sandbox mimics a user's project dir: just tasks.json. The runners
+# resolve shared/PROMPT.md from the repo automatically, so a project
+# needs no local prompt copy unless it wants to customize the template.
 cp "$REPO_DIR/tests/tasks.json" "$SANDBOX/tasks.json"
 
 cat <<EOF


### PR DESCRIPTION
## Summary

- Make `--prompt FILE` optional on both `ralph.sh` and `ralph-prep.sh`: when omitted, the runners auto-resolve `$SHARED_DIR/PROMPT.md` from the installed repo. The `cp shared/PROMPT.md .` ritual is gone.
- Add `prompt FILE` passthrough to the in-session drivers (`/ralph-lnb` and `cc/RALPH-CC.md`) so chat mode has the same escape hatch as headless mode.
- Purge every stale `cp shared/PROMPT.md .` instruction from the docs (root README, tests README, sandbox script, driver doc, skill template prereqs).

Closes #14.

## Behavior change

Projects that were silently relying on auto-pickup of a local `./PROMPT.md` will need to either delete the stale copy or pass `--prompt ./PROMPT.md` explicitly. The shared template is the source of truth going forward.

## Post-merge user action

`install.sh` renders `skill/SKILL.md.template` into a **copy** at `~/.claude/skills/ralph-lnb/SKILL.md`, not a symlink. Anyone who already installed must re-run `install.sh` after pulling to pick up the new `/ralph-lnb` behavior. `install.sh` is idempotent — the re-run is a one-liner.

## Test plan

- [x] `bash -n` on both modified runners
- [x] `ralph --help` shows `(default: repo's shared/PROMPT.md)`
- [x] `ralph-prep.sh --help` shows the same
- [x] `ralph-prep.sh` from a sandbox with only `tasks.json` (no local `PROMPT.md`) emits the filled prompt on stdout, matching `shared/PROMPT.md` after FILL substitution
- [x] `./install.sh` re-renders `~/.claude/skills/ralph-lnb/SKILL.md` with `@@RALPH_REPO@@` substituted; eyeballed the output — prompt row, prereq #3, and Bash() call all correct
- [x] **Headless end-to-end:** `ralph --max-iterations 3` in a sandbox containing only `tasks.json` — runs to `ALL_DONE`, produces `hello.txt` with both expected lines, flips both stories to `passes: true`, populates `.lnb/`. Confirmed against the smoke-test fixture.
- [x] **In-session end-to-end:** `/ralph-lnb max-iterations 3` in a sandbox containing only `tasks.json` — same expectations, same result. Confirms the new `prompt=P` announce line and the default-template auto-resolution work in chat mode.
- [ ] In-session custom prompt path: `/ralph-lnb max-iterations 1, prompt ./custom.md` forwards `--prompt` to `ralph-prep.sh` and runs (manual follow-up)
- [ ] In-session missing prompt path: `/ralph-lnb max-iterations 1, prompt ./missing.md` surfaces `ralph-prep.sh`'s "Prompt file not found" error and stops (manual follow-up)

Unchecked items are the two `prompt=` override scenarios — the happy-path default behavior is confirmed in both modes, so the remaining checks are for the escape-hatch branch only and can be validated post-merge without blocking.

## Review follow-up (commit 2, `3df3267`)

Addressed the two substantive nits from the subagent review:

- **README migration note:** new "Upgrading from an older checkout?" sentence in Quick Start warns existing users about stale `./PROMPT.md`.
- **Announce-line symmetry:** `cc/RALPH-CC.md` and `skill/SKILL.md.template` Setup step 3 now include `prompt=P` in the `Starting ralph loop…` announcement, matching the headless runner's `Prompt:` banner line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)