### PR TITLE
docs: use $RALPH_REPO for clone-path references

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,17 @@ Verify with `lab-notebook --help`. Update later with
 ## Install
 
 ```bash
-git clone https://github.com/carbonscott/ralph-wiggum-lnb ~/codes/ralph-wiggum-lnb
-~/codes/ralph-wiggum-lnb/install.sh
+# Pick any path; snippets below reference $RALPH_REPO so they copy-paste verbatim.
+export RALPH_REPO=~/codes/ralph-wiggum-lnb
+
+git clone https://github.com/carbonscott/ralph-wiggum-lnb "$RALPH_REPO"
+"$RALPH_REPO/install.sh"
 ```
+
+Add the `export` line to your `~/.zshrc` or `~/.bashrc` if you want it
+to persist across new terminals. The installed `ralph` binary and
+`/ralph-lnb` skill don't need it — only snippets in this README and
+`cc/RALPH-CC.md` do.
 
 Two install artifacts:
 
@@ -55,15 +63,14 @@ location with `RALPH_BIN_DIR=/usr/local/bin ./install.sh`. Undo with
 the same value on uninstall so it can find the symlink to remove.
 
 If you prefer not to install, you can still run the scripts by
-absolute path: `~/codes/ralph-wiggum-lnb/cc-headless/ralph.sh` for
-headless mode, or `follow ~/codes/ralph-wiggum-lnb/cc/RALPH-CC.md` in
-a Claude Code session.
+absolute path: `"$RALPH_REPO/cc-headless/ralph.sh"` for headless mode,
+or `follow $RALPH_REPO/cc/RALPH-CC.md` in a Claude Code session.
 
 ## Quick Start
 
 ```bash
 # In your project directory:
-cp ~/codes/ralph-wiggum-lnb/shared/tasks.json.example tasks.json
+cp "$RALPH_REPO/shared/tasks.json.example" tasks.json
 # Edit tasks.json with your stories
 ```
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ location with `RALPH_BIN_DIR=/usr/local/bin ./install.sh`. Undo with
 the same value on uninstall so it can find the symlink to remove.
 
 If you prefer not to install, you can still run the scripts by
-absolute path: `"$RALPH_REPO/cc-headless/ralph.sh"` for headless mode,
+absolute path: `$RALPH_REPO/cc-headless/ralph.sh` for headless mode,
 or `follow $RALPH_REPO/cc/RALPH-CC.md` in a Claude Code session.
 
 ## Quick Start

--- a/cc/RALPH-CC.md
+++ b/cc/RALPH-CC.md
@@ -21,7 +21,7 @@ In a Claude Code chat, type one of:
 
 If you skipped `install.sh`, the long form still works:
 
-> follow ~/codes/ralph-wiggum-lnb/cc/RALPH-CC.md, max-iterations 10
+> follow $RALPH_REPO/cc/RALPH-CC.md, max-iterations 10
 
 Defaults when unspecified:
 
@@ -32,17 +32,21 @@ Defaults when unspecified:
 
 ## Prerequisites
 
-1. The main Claude Code session must be in `acceptEdits` permission mode
+1. `RALPH_REPO` must be exported in the shell where Claude Code runs
+   (e.g. `export RALPH_REPO=~/codes/ralph-wiggum-lnb`). All
+   repo-relative paths below reference `$RALPH_REPO`. Verify with
+   `echo "$RALPH_REPO"`.
+2. The main Claude Code session must be in `acceptEdits` permission mode
    (or you must approve each subagent tool call manually). Subagents
    inherit the parent session's permission mode. This replaces
    `ralph.sh`'s `--permission-mode acceptEdits` flag.
-2. `tasks.json` must exist in the current directory. Copy the starter
-   and edit it: `cp ~/codes/ralph-wiggum-lnb/shared/tasks.json.example tasks.json`,
+3. `tasks.json` must exist in the current directory. Copy the starter
+   and edit it: `cp "$RALPH_REPO/shared/tasks.json.example" tasks.json`,
    then describe your stories. Nothing else needs to live in the
    project dir — the prompt template, `ralph-prep.sh`, `ralph-lib.sh`,
    and `coding-dev.yaml` all stay in the repo and are invoked/sourced
    by absolute path.
-3. `jq` and `lab-notebook` must be on `$PATH` (same as for `ralph.sh`).
+4. `jq` and `lab-notebook` must be on `$PATH` (same as for `ralph.sh`).
 
 ## Procedure for the main Claude Code session
 
@@ -78,7 +82,7 @@ For `i` in `1..max-iterations`:
 1. **Build the prompt.** Call:
 
    ```
-   Bash("$HOME/codes/ralph-wiggum-lnb/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>[ --prompt <prompt>]")
+   Bash("$RALPH_REPO/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>[ --prompt <prompt>]")
    ```
 
    Append `--prompt <prompt>` only if the user supplied one in Setup
@@ -89,10 +93,9 @@ For `i` in `1..max-iterations`:
    the cap alongside the iteration number (matches `ralph.sh`'s log
    format). Capture the tool result's stdout. This is the filled
    prompt. Do not read, quote, or summarize it — just hold it for the
-   next step. Use `$HOME/...` (not `~/...`) inside `Bash()` — the tilde
-   only expands when unquoted, so `$HOME` is safer if the path later
-   gets wrapped in quotes. If the repo lives somewhere other than
-   `$HOME/codes/ralph-wiggum-lnb`, substitute your checkout path.
+   next step. `$RALPH_REPO` must be exported in the shell where the
+   `Bash()` call runs (see Prerequisites item 1); an unset variable
+   yields an empty path and the call fails with a clear error.
 
 2. **Spawn the worker.** Call:
 

--- a/cc/RALPH-CC.md
+++ b/cc/RALPH-CC.md
@@ -56,11 +56,18 @@ minimum specified.
 
 ### Setup
 
-1. Parse `max-iterations`, `task-file`, and `prompt` from the user's
+1. Verify `RALPH_REPO` is exported. Call:
+
+   ```
+   Bash("test -n \"$RALPH_REPO\" || { echo 'RALPH_REPO is not exported; see Prereq item 1' >&2; exit 1; }")
+   ```
+
+   If this fails, stop and report the error to the user. Do not continue.
+2. Parse `max-iterations`, `task-file`, and `prompt` from the user's
    message. Apply defaults for anything unspecified. `prompt` is
    optional — if the user did not supply it, leave it unset and omit
    `--prompt` from the `ralph-prep.sh` call in Loop step 1.
-2. Derive the notebook context once, so every subsequent log call uses
+3. Derive the notebook context once, so every subsequent log call uses
    the same value:
 
    ```
@@ -69,7 +76,7 @@ minimum specified.
 
    Capture stdout into `<context>`. This mirrors how `ralph-prep.sh`
    derives it, so both runners agree on the context slug.
-3. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X, prompt=P, context=<context>"`.
+4. Announce once: `"Starting ralph loop, max-iterations=N, task-file=X, prompt=P, context=<context>"`.
    One line, nothing more. Use the user-supplied prompt path for `P`
    if they passed one; otherwise use the literal string
    `shared/PROMPT.md` so readers can tell at a glance which template
@@ -86,7 +93,7 @@ For `i` in `1..max-iterations`:
    ```
 
    Append `--prompt <prompt>` only if the user supplied one in Setup
-   step 1; otherwise omit the flag so `ralph-prep.sh` uses its own
+   step 2; otherwise omit the flag so `ralph-prep.sh` uses its own
    default (`shared/PROMPT.md`).
 
    Pass the same `N` you parsed in Setup so the start log entry records
@@ -119,7 +126,7 @@ For `i` in `1..max-iterations`:
 
    - Contains `<promise>ALL_DONE</promise>`:
      - Call `Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook emit --context <context> --type done --tags ralph-harness 'ralph-cc: all stories complete at iteration i'")`
-       using the `<context>` derived in Setup step 2.
+       using the `<context>` derived in Setup step 3.
      - Break the loop. Go to "Post-loop".
    - Contains `<promise>DONE</promise>`:
      - Say exactly: `"iteration i: DONE, continuing"`. One line.
@@ -132,7 +139,7 @@ For `i` in `1..max-iterations`:
 ### Post-loop
 
 1. If the loop ended on `ALL_DONE`, optionally query the notebook for a
-   summary, using the `<context>` derived in Setup step 2:
+   summary, using the `<context>` derived in Setup step 3:
 
    ```
    Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook sql \"SELECT ts, type, issue, substr(content,1,200) FROM entries WHERE context='<context>' AND type IN ('start','done','impl','blocker') ORDER BY ts\"")

--- a/install.sh
+++ b/install.sh
@@ -30,8 +30,9 @@ Usage: install.sh [--force]
 
 Installs ralph-wiggum-lnb entry points. Run from a fresh git clone:
 
-    git clone <url> ~/codes/ralph-wiggum-lnb
-    ~/codes/ralph-wiggum-lnb/install.sh
+    export RALPH_REPO=~/codes/ralph-wiggum-lnb   # or wherever you want it
+    git clone <url> "$RALPH_REPO"
+    "$RALPH_REPO/install.sh"
 
 Environment variables:
   RALPH_BIN_DIR   Where to put the `ralph` symlink. Default: ~/.local/bin
@@ -137,6 +138,10 @@ cat <<EOF
 Done. Quick usage:
   ralph --max-iterations 3                 # headless mode
   /ralph-lnb max-iterations 3              # in a Claude Code chat
+
+Tip: if you plan to use RALPH-CC.md or the uninstalled fallback, add
+  export RALPH_REPO="$REPO"
+to your ~/.zshrc or ~/.bashrc.
 
 EOF
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `~/codes/ralph-wiggum-lnb` with `$RALPH_REPO` in all user-facing snippets so they copy-paste verbatim regardless of clone location.
- README Install section grows an `export RALPH_REPO=...` preamble + persistence note; skip-install bullet and Quick Start `cp` use the var.
- `cc/RALPH-CC.md` gains a new Prereq item 1 requiring `RALPH_REPO`; the runtime `Bash("$RALPH_REPO/cc/ralph-prep.sh …")` call in Loop step 1 drops the old `$HOME`-vs-tilde workaround.
- `install.sh` `--help` heredoc mirrors the new convention; post-install prints a concrete `export RALPH_REPO="<abs-path>"` tip for users who want to add it to their rc.
- No runtime code touched. `skill/SKILL.md.template` already parameterizes via `@@RALPH_REPO@@` substitution, so installed users continue to see concrete absolute paths.

## Test plan
- [x] `install.sh --help` renders literal `$RALPH_REPO` (single-quoted heredoc).
- [x] Re-running `install.sh` prints the tip with `$REPO` expanded to the concrete absolute path.
- [x] `grep -rn '~/codes/ralph-wiggum-lnb\|/ralph-wiggum-lnb/'` returns only the intentional example-value assignments in the three setup snippets.
- [ ] Reviewer sanity-check: docs read naturally end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)