### PR TITLE
refactor: hand off ralph-lnb prompt via RALPH-PROMPT.md instead of stdout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .lnb.env
 .lnb/
+RALPH-PROMPT.md

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ The repo splits into four directories so the mode boundary is obvious:
 | File | Purpose |
 |------|---------|
 | `cc-headless/ralph.sh` | Headless runner — uses `claude -p` |
-| `cc/ralph-prep.sh` | Per-iteration bookkeeping + prompt builder invoked by the `/ralph-lnb` skill; stdout is the filled prompt |
+| `cc/ralph-prep.sh` | Per-iteration bookkeeping + prompt builder invoked by the `/ralph-lnb` skill; writes the filled prompt to `RALPH-PROMPT.md`, stdout is a one-line status |
 | `skill/SKILL.md.template` | Skill template — `install.sh` renders this into `~/.claude/skills/ralph-lnb/SKILL.md` with absolute paths |
 | `shared/ralph-lib.sh` | Shared bash helpers sourced by both runners |
 | `shared/PROMPT.md` | Prompt template with `<!-- FILL:xxx -->` markers |

--- a/cc/ralph-prep.sh
+++ b/cc/ralph-prep.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 # Per-iteration bookkeeping + prompt builder for the /ralph-lnb skill.
-# Prints the filled prompt to stdout so a Claude Code session can capture
-# it and pass it to Agent(). Diagnostics go to stderr.
+# Writes the filled prompt to RALPH-PROMPT.md in the project dir and prints
+# only a one-line status to stdout, so the Claude Code session can point a
+# subagent at the file without holding the prompt in its own context.
+# Diagnostics go to stderr.
 
 # --- Defaults ---
 PROMPT_FILE=""
@@ -31,9 +33,10 @@ usage() {
 Usage: ralph-prep.sh [OPTIONS]
 
 Runs one iteration of ralph bookkeeping (archive, notebook init, history
-query, prompt fill) and prints the filled PROMPT.md to stdout. Intended
-to be invoked by a Claude Code session that then passes the stdout to
-the Agent() tool — see the /ralph-lnb skill (skill/SKILL.md.template).
+query, prompt fill) and writes the filled prompt to RALPH-PROMPT.md in the
+project dir, printing only a one-line status to stdout. Intended to be
+invoked by a Claude Code session that then points a subagent at that file
+via the Agent() tool — see the /ralph-lnb skill (skill/SKILL.md.template).
 
 Options:
   --prompt FILE           Custom prompt template (default: repo's shared/PROMPT.md)
@@ -108,15 +111,23 @@ fi
 archive_previous_run
 ensure_notebook
 
-# --- Emit filled prompt to stdout ---
+# --- Write filled prompt to RALPH-PROMPT.md ---
 # Query history BEFORE logging "start" so the recent_history block sees
 # only prior iterations' entries — matches cc-headless/ralph.sh ordering
 # (see ralph.sh:150-154) so both runners build byte-identical prompts.
 history=$(query_recent_history)
-build_prompt "$history"
 
+# Write the filled prompt to a file in the project dir (parent of the
+# notebook dir) instead of stdout, so the /ralph-lnb main agent never has
+# to hold the full prompt in its context. The subagent reads this file.
+# With the default NOTEBOOK_DIR=.lnb, dirname resolves to "." (project dir).
+PROMPT_OUT="$(dirname "$NOTEBOOK_DIR")/RALPH-PROMPT.md"
+build_prompt "$history" > "$PROMPT_OUT"
+echo "Wrote iteration $ITERATION prompt to $PROMPT_OUT"
+
+# Route the emit confirmation to stderr so stdout stays a single status line.
 if [[ -n "$MAX_ITERATIONS" ]]; then
-    log_to_notebook "start" "ralph-lnb: starting iteration $ITERATION/$MAX_ITERATIONS"
+    log_to_notebook "start" "ralph-lnb: starting iteration $ITERATION/$MAX_ITERATIONS" >&2
 else
-    log_to_notebook "start" "ralph-lnb: starting iteration $ITERATION"
+    log_to_notebook "start" "ralph-lnb: starting iteration $ITERATION" >&2
 fi

--- a/cc/ralph-prep.sh
+++ b/cc/ralph-prep.sh
@@ -117,15 +117,15 @@ ensure_notebook
 # (see ralph.sh:150-154) so both runners build byte-identical prompts.
 history=$(query_recent_history)
 
-# Write the filled prompt to a file in the project dir (parent of the
-# notebook dir) instead of stdout, so the /ralph-lnb main agent never has
-# to hold the full prompt in its context. The subagent reads this file.
-# With the default NOTEBOOK_DIR=.lnb, dirname resolves to "." (project dir).
-PROMPT_OUT="$(dirname "$NOTEBOOK_DIR")/RALPH-PROMPT.md"
+# Write the filled prompt to RALPH-PROMPT.md in the cwd instead of stdout,
+# so the /ralph-lnb main agent never has to hold the full prompt in its
+# context. The subagent reads this file at the same fixed path (the skill's
+# Agent() call hardcodes ./RALPH-PROMPT.md), so anchor it to the cwd here.
+PROMPT_OUT="./RALPH-PROMPT.md"
 build_prompt "$history" > "$PROMPT_OUT"
 echo "Wrote iteration $ITERATION prompt to $PROMPT_OUT"
 
-# Route the emit confirmation to stderr so stdout stays a single status line.
+# Route lab-notebook's start-entry output to stderr so stdout stays a single status line.
 if [[ -n "$MAX_ITERATIONS" ]]; then
     log_to_notebook "start" "ralph-lnb: starting iteration $ITERATION/$MAX_ITERATIONS" >&2
 else

--- a/skill/SKILL.md.template
+++ b/skill/SKILL.md.template
@@ -74,15 +74,15 @@ For `i` in `1..max-iterations`:
 
    Append `--prompt <prompt>` only if the user supplied one in Setup step 1; otherwise omit the flag so `ralph-prep.sh` uses its own default (`shared/PROMPT.md`).
 
-   Pass the same `N` you parsed in Setup so the start log entry records the cap alongside the iteration number (matches `cc-headless/ralph.sh`'s log format). Capture the tool result's stdout. This is the filled prompt. Do not read, quote, or summarize it — just hold it for the next step.
+   Pass the same `N` you parsed in Setup so the start log entry records the cap alongside the iteration number (matches `cc-headless/ralph.sh`'s log format). `ralph-prep.sh` writes the filled prompt to `RALPH-PROMPT.md` in the project directory (the cwd) and prints only a one-line status to stdout — it does **not** print the prompt. Do not capture or hold the prompt; it never enters your context. Just confirm the Bash call succeeded.
 
-2. **Spawn the worker.** Call:
+2. **Spawn the worker.** Call (the prompt is a fixed string — the subagent reads the real instructions from the file):
 
    ```
    Agent(
        subagent_type="general-purpose",
        description="ralph iteration i",
-       prompt=<stdout from step 1>
+       prompt="Read ./RALPH-PROMPT.md in the current working directory and follow its instructions exactly. If that file is missing or empty, stop and report it instead of proceeding."
    )
    ```
 
@@ -122,10 +122,10 @@ For `i` in `1..max-iterations`:
 
 ## Context budgeting
 
-Each iteration adds ~50 tokens (the subagent's final narration plus the promise marker) to the main session's context. A 20-iteration run is roughly 1k tokens — acceptable. Keep your own between-iteration narration to one short line (`"iteration i: DONE, continuing"`). Do not summarize subagent output, do not re-read `tasks.json` yourself (`ralph-prep.sh` already does it every iteration), do not print anything the user doesn't need.
+The filled prompt (notebook context + full `tasks.json` + recent history) never enters the main session's context: `ralph-prep.sh` writes it to `RALPH-PROMPT.md` and the subagent reads it directly. Each iteration adds only the prep status line plus the subagent's final narration and promise marker — on the order of tens of tokens. Keep your own between-iteration narration to one short line (`"iteration i: DONE, continuing"`). Do not read `RALPH-PROMPT.md` yourself, do not summarize subagent output, do not re-read `tasks.json` yourself (`ralph-prep.sh` already folds it into the prompt file every iteration), do not print anything the user doesn't need.
 
 ## Relationship to the headless runner
 
-The headless runner `@@RALPH_REPO@@/cc-headless/ralph.sh` uses the same `ralph-prep.sh`, `shared/ralph-lib.sh`, `shared/PROMPT.md`, `tasks.json`, and `.lnb/` state. A change to `shared/ralph-lib.sh` affects both runners. The only difference is who spawns the per-iteration agent: `claude -p` in headless, `Agent()` in this skill.
+The headless runner `@@RALPH_REPO@@/cc-headless/ralph.sh` shares `shared/ralph-lib.sh`, `shared/PROMPT.md`, `tasks.json`, and `.lnb/` state with this skill. A change to `shared/ralph-lib.sh` (e.g. `build_prompt`) affects both runners. `ralph-prep.sh` is used only by this skill — headless calls `build_prompt` directly and pipes the prompt to `claude -p`, whereas this skill has `ralph-prep.sh` write the prompt to `RALPH-PROMPT.md` for a fresh `Agent()` subagent to read.
 
 $ARGUMENTS


### PR DESCRIPTION
## Problem

In the non-headless `/ralph-lnb` skill, the main agent is a pure shuttle but pays for the whole prompt anyway. `ralph-prep.sh` printed the **entire filled prompt** (notebook context + full `tasks.json` + recent history) to stdout, which landed in the main session's transcript as a Bash tool result — and the same text was then passed again as the `Agent(prompt=...)` input. So the full prompt entered the main agent's context **twice per iteration** and accumulated across all iterations (thousands of tokens × N), even though the main agent only needs the subagent's `<promise>` markers.

## Fix (file handoff)

`ralph-prep.sh` now writes the filled prompt to `RALPH-PROMPT.md` in the project dir (parent of `.lnb`) and prints only a one-line status to stdout. The `Agent()` call is a fixed string telling the subagent to read that file. The prompt lands in the subagent's context, where it belongs; the main agent's per-iteration cost drops to ~one status line.

## Changes

- **`cc/ralph-prep.sh`** — redirect `build_prompt` output into `RALPH-PROMPT.md`; emit a single status line; route the notebook `start`-emit confirmation to stderr so stdout stays one line. Header/usage comments updated.
- **`skill/SKILL.md.template`** — Loop step 1 (prompt goes to file, not stdout), Loop step 2 (fixed `Agent()` prompt reading `RALPH-PROMPT.md`), corrected "Context budgeting" section (old ~50-token claim ignored the prompt body), and fixed the inaccurate "headless uses the same ralph-prep.sh" note.
- **`.gitignore`** — ignore `RALPH-PROMPT.md`.

## Scope

`build_prompt` (`shared/ralph-lib.sh`) and the headless runner (`cc-headless/ralph.sh`) are **untouched** — headless calls `build_prompt` directly and depends on its stdout. `ralph-prep.sh` is skill-only.

## Verification

- Stdout is a single status line per iteration (tested two iterations).
- `RALPH-PROMPT.md` is fully filled — 0 leftover `FILL:` markers; iteration 2 picks up prior history.
- `.lnb/` initialized, `start` entry logged.
- `git diff` confirms `shared/ralph-lib.sh` and `cc-headless/` unchanged.
- After `./install.sh`, the regenerated skill reads `RALPH-PROMPT.md` and shows the corrected budgeting section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)