### PR TITLE
Consolidate ralph state under a gitignored .ralph/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .lnb.env
-.lnb/
-RALPH-PROMPT.md
+.ralph/

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ customize the template. **Upgrading from an older checkout?** A stale
 it if you never customized it, or pass `--prompt ./PROMPT.md`
 explicitly if you did.
 
-The runner auto-initializes `.lnb/` with the coding schema on the first
-iteration — no manual `lab-notebook init` needed.
+The runner auto-initializes `.ralph/.lnb` with the coding schema on the
+first iteration — no manual `lab-notebook init` needed.
 
 Then pick one runner:
 
@@ -94,19 +94,24 @@ Start Claude Code in `acceptEdits` mode, then in the session:
 (Restart any running Claude Code sessions after install — skills load
 at session start.)
 
-`tasks.json` is the entire footprint in your project dir. The prompt
-template, shared lib, helper scripts, and notebook schema all stay in
-the repo and are invoked or sourced by `ralph` / `/ralph-lnb` (or by
-absolute path if you skipped install).
+`tasks.json` is the only file you author and commit in your project
+dir. Everything ralph generates — the notebook, the per-iteration
+prompt, the batch cursor, and archived `tasks.json` snapshots — lives
+under one gitignored `.ralph/` directory, with a small `.lnb.env`
+pointer at the root so a bare `/lnb recall` finds the notebook; a reset
+is just `rm -rf .ralph/`. The prompt template, shared lib, helper
+scripts, and notebook schema all stay in the repo and are invoked or
+sourced by `ralph` / `/ralph-lnb` (or by absolute path if you skipped
+install).
 
 ## How It Works
 
 ```
-tasks.json (what to do)  +  .lnb/ (what happened)  +  PROMPT.md (how to do it)
-           │                       │                           │
-           └───────────┬───────────┘                           │
-                       ▼                                       │
-              runner   builds prompt ◄─────────────────────────┘
+tasks.json (what to do)  +  .ralph/.lnb (what happened)  +  PROMPT.md (how to do it)
+           │                             │                           │
+           └───────────┬─────────────────┘                           │
+                       ▼                                             │
+              runner   builds prompt ◄───────────────────────────────┘
                      │
               ┌──────┴──────────────────────┐
               │  for each iteration:        │
@@ -123,7 +128,7 @@ tasks.json (what to do)  +  .lnb/ (what happened)  +  PROMPT.md (how to do it)
 ## Two runners, same loop
 
 Ralph ships two entry points that share the same `PROMPT.md`, `tasks.json`,
-`.lnb/`, and `archive/` state:
+and `.ralph/` state (notebook, per-iteration prompt, batch cursor, archives):
 
 - **`ralph`** (headless, terminal) — runs in a terminal and spawns a
   fresh `claude -p` per iteration. Truly stateless outer loop. Backed
@@ -161,7 +166,7 @@ The repo splits into four directories so the mode boundary is obvious:
 | File | Purpose |
 |------|---------|
 | `cc-headless/ralph.sh` | Headless runner — uses `claude -p` |
-| `cc/ralph-prep.sh` | Per-iteration bookkeeping + prompt builder invoked by the `/ralph-lnb` skill; writes the filled prompt to `RALPH-PROMPT.md`, stdout is a one-line status |
+| `cc/ralph-prep.sh` | Per-iteration bookkeeping + prompt builder invoked by the `/ralph-lnb` skill; writes the filled prompt to `.ralph/prompt.md`, stdout is a one-line status |
 | `skill/SKILL.md.template` | Skill template — `install.sh` renders this into `~/.claude/skills/ralph-lnb/SKILL.md` with absolute paths |
 | `shared/ralph-lib.sh` | Shared bash helpers sourced by both runners |
 | `shared/PROMPT.md` | Prompt template with `<!-- FILL:xxx -->` markers |
@@ -217,7 +222,7 @@ The `coding-dev.yaml` schema provides entry types tailored for coding:
 
 Query patterns from all iterations:
 ```bash
-LAB_NOTEBOOK_DIR=.lnb lab-notebook sql \
+LAB_NOTEBOOK_DIR=.ralph/.lnb lab-notebook sql \
   "SELECT content FROM entries WHERE type='pattern' ORDER BY ts"
 ```
 
@@ -227,9 +232,11 @@ LAB_NOTEBOOK_DIR=.lnb lab-notebook sql \
 --max-iterations N      Safety cap (default: 10)
 --prompt FILE           Custom prompt template (default: repo's shared/PROMPT.md)
 --task-file FILE        Task file (default: tasks.json)
---notebook DIR          Notebook directory (default: .lnb)
+--notebook DIR          Notebook directory (default: .ralph/.lnb)
 --context SLUG          Notebook context (default: from branch)
---archive-dir DIR       Archive directory (default: archive/)
+--archive-dir DIR       Archive directory (default: .ralph/archive)
+--force                 Re-spin even when this branch's all-green batch
+                        was already recorded complete in .ralph/state.json
 ```
 
 For the Claude Code session runner, invoke it as `/ralph-lnb
@@ -240,8 +247,11 @@ in this repo for the pre-substitution source).
 
 ## Archive
 
-When the `branch` field in `tasks.json` changes between runs, both runners
-archive the previous task file and notebook to `archive/<date>-<branch>/`.
+When the recorded cursor in `.ralph/state.json` shows the `branch` has
+changed since the last run, both runners snapshot the previous
+`tasks.json` — only the task file, not the notebook (it self-archives by
+`context`) — to `.ralph/archive/<date>-<branch>/`. A first run records the
+cursor and archives nothing; a same-branch re-run archives nothing.
 
 ## Shared notebook across loops / worktrees
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ customize the template. **Upgrading from an older checkout?** A stale
 it if you never customized it, or pass `--prompt ./PROMPT.md`
 explicitly if you did.
 
+On the next run, ralph also relocates any old-layout state — `./.lnb`,
+`./.ralph-last-branch`, and `./archive/` — into `.ralph/` and rewrites
+the root `.lnb.env` pointer. The move is one-time and idempotent: once
+the state lives under `.ralph/`, later runs leave it alone. If any of
+those old paths were committed to git, ralph prints a `git rm --cached
+.ralph-last-branch archive` hint — run it to drop those stale index
+entries now that their content lives under the gitignored `.ralph/`
+(ralph never runs git itself).
+
 The runner auto-initializes `.ralph/.lnb` with the coding schema on the
 first iteration — no manual `lab-notebook init` needed.
 
@@ -98,8 +107,10 @@ at session start.)
 dir. Everything ralph generates — the notebook, the per-iteration
 prompt, the batch cursor, and archived `tasks.json` snapshots — lives
 under one gitignored `.ralph/` directory, with a small `.lnb.env`
-pointer at the root so a bare `/lnb recall` finds the notebook; a reset
-is just `rm -rf .ralph/`. The prompt template, shared lib, helper
+pointer at the root so a bare `/lnb recall` finds the notebook; a full
+reset is `rm -rf .ralph/ .lnb.env` (the root pointer lives outside
+`.ralph/`, so dropping it too avoids a dangling reference until the
+next run regenerates it). The prompt template, shared lib, helper
 scripts, and notebook schema all stay in the repo and are invoked or
 sourced by `ralph` / `/ralph-lnb` (or by absolute path if you skipped
 install).

--- a/README.md
+++ b/README.md
@@ -242,3 +242,21 @@ in this repo for the pre-substitution source).
 
 When the `branch` field in `tasks.json` changes between runs, both runners
 archive the previous task file and notebook to `archive/<date>-<branch>/`.
+
+## Shared notebook across loops / worktrees
+
+By default each project dir (or git worktree) is its own cwd and gets its own
+`.ralph/.lnb` notebook — no setup, no contention.
+
+For the power user who wants several loops to *share* one notebook (e.g. one
+notebook spanning several worktrees so each loop can learn from the others),
+point them all at one path with `--notebook <shared-path>`. There is no extra
+flag: ralph attributes every entry to a per-loop writer
+`ralph-<branch>` (the branch slug from `tasks.json`, e.g. branch `ralph/foo`
+&rarr; writer `ralph-foo`), via `LAB_NOTEBOOK_WRITER` set on each
+`lab-notebook emit` call. Because the notebook stores one append-only
+`entries/<writer>.jsonl` per writer, concurrent loops on different branches
+never collide — each writes its own file, and a single `lab-notebook sql`
+query still sees them all. (Two loops sharing **one** branch in **one** cwd
+still share both the prompt file and the writer; real isolation is separate
+cwds/worktrees and/or distinct branches.)

--- a/cc-headless/ralph.sh
+++ b/cc-headless/ralph.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 MAX_ITERATIONS=10
 PROMPT_FILE=""
 TASK_FILE="tasks.json"
-NOTEBOOK_DIR=".lnb"
+NOTEBOOK_DIR=".ralph/.lnb"
 CONTEXT=""
 ARCHIVE_DIR="archive"
 COMPLETION_PROMISE="DONE"
@@ -34,7 +34,7 @@ Options:
   --max-iterations N      Safety cap (default: 10)
   --prompt FILE           Custom prompt template (default: repo's shared/PROMPT.md)
   --task-file FILE        Task file with stories (default: tasks.json)
-  --notebook DIR          Lab-notebook directory (default: .lnb)
+  --notebook DIR          Lab-notebook directory (default: .ralph/.lnb)
   --context SLUG          Notebook context (default: derived from branch)
   --archive-dir DIR       Where to archive old runs (default: archive/)
   -h, --help              Show this help

--- a/cc-headless/ralph.sh
+++ b/cc-headless/ralph.sh
@@ -7,9 +7,10 @@ PROMPT_FILE=""
 TASK_FILE="tasks.json"
 NOTEBOOK_DIR=".ralph/.lnb"
 CONTEXT=""
-ARCHIVE_DIR="archive"
+ARCHIVE_DIR=".ralph/archive"
 COMPLETION_PROMISE="DONE"
 ALL_DONE_PROMISE="ALL_DONE"
+FORCE=0
 
 # Resolve symlinks so SHARED_DIR is correct when the runner is symlinked
 # into $PATH. Walks a chain of relative or absolute symlinks.
@@ -36,7 +37,11 @@ Options:
   --task-file FILE        Task file with stories (default: tasks.json)
   --notebook DIR          Lab-notebook directory (default: .ralph/.lnb)
   --context SLUG          Notebook context (default: derived from branch)
-  --archive-dir DIR       Where to archive old runs (default: archive/)
+  --archive-dir DIR       Where to archive old runs (default: .ralph/archive)
+  --force                 Re-spin even when this branch's all-green batch was
+                          already recorded complete in .ralph/state.json.
+                          Bypasses the refuse-respin guard only; archive
+                          behavior is unchanged.
   -h, --help              Show this help
 
 The loop exits when:
@@ -61,6 +66,7 @@ while [[ $# -gt 0 ]]; do
         --notebook)        NOTEBOOK_DIR="$2"; shift 2 ;;
         --context)         CONTEXT="$2"; shift 2 ;;
         --archive-dir)     ARCHIVE_DIR="$2"; shift 2 ;;
+        --force)           FORCE=1; shift ;;
         -h|--help)         usage ;;
         *)                 echo "Unknown option: $1" >&2; usage ;;
     esac
@@ -94,7 +100,7 @@ else
 fi
 
 # --- Shared helpers ---
-LAST_BRANCH_FILE=".ralph-last-branch"
+STATE_FILE=".ralph/state.json"
 source "$SHARED_DIR/ralph-lib.sh"
 
 # --- Read task file metadata ---
@@ -125,6 +131,18 @@ format_stream() {
         end
     ' 2>/dev/null
 }
+
+# --- Refuse re-spinning an already-completed batch (G3) ---
+# If this branch's batch is all-green AND was recorded complete in
+# .ralph/state.json, refuse to loop again. --force bypasses this guard only;
+# it does not change archive behavior. Checked before archiving so a finished
+# batch never touches state.
+if [[ "$FORCE" -ne 1 ]] && batch_already_complete; then
+    echo "=== Batch already complete ==="
+    echo "Branch '${BRANCH:-<none>}': all stories pass and this batch was recorded complete in $STATE_FILE."
+    echo "Nothing to do. Add or unset stories in $TASK_FILE (or start a new branch), or pass --force to re-spin anyway."
+    exit 0
+fi
 
 # --- Main ---
 archive_previous_run
@@ -178,6 +196,9 @@ for i in $(seq 1 "$MAX_ITERATIONS"); do
     if echo "$AGENT_TEXT" | grep -q "<promise>${ALL_DONE_PROMISE}</promise>"; then
         echo ""
         echo "=== All stories complete! ==="
+        # Record this batch complete so a re-spin of the all-green tasks.json
+        # is refused next time (see batch_already_complete / the startup guard).
+        record_batch_complete
         log_to_notebook "done" "ralph.sh: all stories complete at iteration $i"
         break
     elif echo "$AGENT_TEXT" | grep -q "<promise>${COMPLETION_PROMISE}</promise>"; then

--- a/cc-headless/ralph.sh
+++ b/cc-headless/ralph.sh
@@ -145,6 +145,12 @@ if [[ "$FORCE" -ne 1 ]] && batch_already_complete; then
 fi
 
 # --- Main ---
+# Migrate any OLD on-disk layout (./.lnb, ./.ralph-last-branch, ./archive) into
+# .ralph/ BEFORE archive bookkeeping, so archive_previous_run reads the migrated
+# cursor (.ralph/state.json) and detects a real branch transition. Idempotent
+# no-op on already-migrated / fresh trees. (ensure_notebook also calls this, so
+# the shim is reached even if a future caller skips this line.)
+migrate_old_layout
 archive_previous_run
 ensure_notebook
 

--- a/cc/ralph-prep.sh
+++ b/cc/ralph-prep.sh
@@ -12,10 +12,12 @@ PROMPT_FILE=""
 TASK_FILE="tasks.json"
 NOTEBOOK_DIR=".ralph/.lnb"
 CONTEXT=""
-ARCHIVE_DIR="archive"
+ARCHIVE_DIR=".ralph/archive"
 ITERATION="1"
 MAX_ITERATIONS=""
-LAST_BRANCH_FILE=".ralph-last-branch"
+STATE_FILE=".ralph/state.json"
+FORCE=0
+RECORD_COMPLETE=0
 
 # Resolve symlinks so SHARED_DIR is correct when the runner is symlinked
 # into $PATH. Walks a chain of relative or absolute symlinks.
@@ -43,13 +45,23 @@ Options:
   --task-file FILE        Task file with stories (default: tasks.json)
   --notebook DIR          Lab-notebook directory (default: .ralph/.lnb)
   --context SLUG          Notebook context (default: derived from branch)
-  --archive-dir DIR       Where to archive old runs (default: archive/)
+  --archive-dir DIR       Where to archive old runs (default: .ralph/archive)
   --iteration N           Iteration number, used in the start log entry
                           (default: 1)
   --max-iterations N      Iteration cap, recorded alongside --iteration
                           in the start log entry (optional). Does not
                           affect the loop — the Claude Code session
                           enforces the cap via the /ralph-lnb skill.
+  --force                 Bypass the refuse-respin guard: prep a prompt even
+                          when this branch's all-green batch was already
+                          recorded complete in .ralph/state.json. Only
+                          overrides the guard; archive behavior is unchanged.
+  --record-complete       Record this branch's batch as complete in
+                          .ralph/state.json and exit (do not prep a prompt).
+                          The /ralph-lnb skill calls this after a subagent
+                          returns <promise>ALL_DONE</promise>, so a later
+                          re-spin of the all-green batch is refused (the
+                          headless runner records this inline on ALL_DONE).
   -h, --help              Show this help
 EOF
     exit 0
@@ -65,6 +77,8 @@ while [[ $# -gt 0 ]]; do
         --archive-dir)     ARCHIVE_DIR="$2"; shift 2 ;;
         --iteration)       ITERATION="$2"; shift 2 ;;
         --max-iterations)  MAX_ITERATIONS="$2"; shift 2 ;;
+        --force)           FORCE=1; shift ;;
+        --record-complete) RECORD_COMPLETE=1; shift ;;
         -h|--help)         usage ;;
         *)                 echo "Unknown option: $1" >&2; usage ;;
     esac
@@ -104,10 +118,32 @@ if [[ -z "$CONTEXT" ]]; then
     fi
 fi
 
+# --- Record batch completion and exit (G3) ---
+# Called by the /ralph-lnb skill after a subagent returns ALL_DONE, so a later
+# re-spin of the all-green batch is refused. Records and exits without prepping
+# a prompt or touching the notebook.
+if [[ "$RECORD_COMPLETE" -eq 1 ]]; then
+    record_batch_complete
+    echo "Recorded batch complete for branch '${BRANCH:-<none>}' in $STATE_FILE"
+    exit 0
+fi
+
+# --- Refuse re-spinning an already-completed batch (G3) ---
+# If this branch's batch is all-green AND was recorded complete in
+# .ralph/state.json, do not prep another prompt — print a clear message and
+# exit non-zero so the /ralph-lnb skill stops the loop instead of looping on a
+# fully-passing tasks.json. --force bypasses this guard (archive behavior is
+# unchanged). Checked before archiving so a finished batch never touches state.
+if [[ "$FORCE" -ne 1 ]] && batch_already_complete; then
+    echo "Batch already complete for branch '${BRANCH:-<none>}': all stories pass and this batch was recorded complete in $STATE_FILE." >&2
+    echo "Nothing to do. Add or unset stories in $TASK_FILE (or start a new branch), or pass --force to re-spin anyway." >&2
+    exit 3
+fi
+
 # --- Bookkeeping ---
 # archive_previous_run and ensure_notebook are both idempotent — safe to
-# call on every iteration. archive_previous_run only actually archives
-# when BRANCH differs from $LAST_BRANCH_FILE's contents.
+# call on every iteration. archive_previous_run only actually archives on a
+# real branch transition (recorded cursor in $STATE_FILE differs from BRANCH).
 archive_previous_run
 ensure_notebook
 

--- a/cc/ralph-prep.sh
+++ b/cc/ralph-prep.sh
@@ -141,6 +141,12 @@ if [[ "$FORCE" -ne 1 ]] && batch_already_complete; then
 fi
 
 # --- Bookkeeping ---
+# Migrate any OLD on-disk layout (./.lnb, ./.ralph-last-branch, ./archive) into
+# .ralph/ BEFORE archive bookkeeping, so archive_previous_run reads the migrated
+# cursor (.ralph/state.json) and detects a real branch transition. Idempotent
+# no-op on already-migrated / fresh trees. (ensure_notebook also calls this, so
+# the shim is reached even if a future caller skips this line.)
+migrate_old_layout
 # archive_previous_run and ensure_notebook are both idempotent — safe to
 # call on every iteration. archive_previous_run only actually archives on a
 # real branch transition (recorded cursor in $STATE_FILE differs from BRANCH).

--- a/cc/ralph-prep.sh
+++ b/cc/ralph-prep.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Per-iteration bookkeeping + prompt builder for the /ralph-lnb skill.
-# Writes the filled prompt to RALPH-PROMPT.md in the project dir and prints
+# Writes the filled prompt to .ralph/prompt.md in the project dir and prints
 # only a one-line status to stdout, so the Claude Code session can point a
 # subagent at the file without holding the prompt in its own context.
 # Diagnostics go to stderr.
@@ -10,7 +10,7 @@ set -euo pipefail
 # --- Defaults ---
 PROMPT_FILE=""
 TASK_FILE="tasks.json"
-NOTEBOOK_DIR=".lnb"
+NOTEBOOK_DIR=".ralph/.lnb"
 CONTEXT=""
 ARCHIVE_DIR="archive"
 ITERATION="1"
@@ -33,7 +33,7 @@ usage() {
 Usage: ralph-prep.sh [OPTIONS]
 
 Runs one iteration of ralph bookkeeping (archive, notebook init, history
-query, prompt fill) and writes the filled prompt to RALPH-PROMPT.md in the
+query, prompt fill) and writes the filled prompt to .ralph/prompt.md in the
 project dir, printing only a one-line status to stdout. Intended to be
 invoked by a Claude Code session that then points a subagent at that file
 via the Agent() tool — see the /ralph-lnb skill (skill/SKILL.md.template).
@@ -41,7 +41,7 @@ via the Agent() tool — see the /ralph-lnb skill (skill/SKILL.md.template).
 Options:
   --prompt FILE           Custom prompt template (default: repo's shared/PROMPT.md)
   --task-file FILE        Task file with stories (default: tasks.json)
-  --notebook DIR          Lab-notebook directory (default: .lnb)
+  --notebook DIR          Lab-notebook directory (default: .ralph/.lnb)
   --context SLUG          Notebook context (default: derived from branch)
   --archive-dir DIR       Where to archive old runs (default: archive/)
   --iteration N           Iteration number, used in the start log entry
@@ -111,17 +111,18 @@ fi
 archive_previous_run
 ensure_notebook
 
-# --- Write filled prompt to RALPH-PROMPT.md ---
+# --- Write filled prompt to .ralph/prompt.md ---
 # Query history BEFORE logging "start" so the recent_history block sees
 # only prior iterations' entries — matches cc-headless/ralph.sh ordering
 # (see ralph.sh:150-154) so both runners build byte-identical prompts.
 history=$(query_recent_history)
 
-# Write the filled prompt to RALPH-PROMPT.md in the cwd instead of stdout,
+# Write the filled prompt to .ralph/prompt.md in the cwd instead of stdout,
 # so the /ralph-lnb main agent never has to hold the full prompt in its
 # context. The subagent reads this file at the same fixed path (the skill's
-# Agent() call hardcodes ./RALPH-PROMPT.md), so anchor it to the cwd here.
-PROMPT_OUT="./RALPH-PROMPT.md"
+# Agent() call hardcodes .ralph/prompt.md), so anchor it to the cwd here.
+mkdir -p .ralph
+PROMPT_OUT=".ralph/prompt.md"
 build_prompt "$history" > "$PROMPT_OUT"
 echo "Wrote iteration $ITERATION prompt to $PROMPT_OUT"
 

--- a/shared/PROMPT.md
+++ b/shared/PROMPT.md
@@ -35,7 +35,7 @@ the end. Log whenever something meaningful happens:
 
 Command template:
 ```
-LAB_NOTEBOOK_DIR=<!-- FILL:notebook_dir --> lab-notebook emit \
+LAB_NOTEBOOK_DIR=<!-- FILL:notebook_dir --> LAB_NOTEBOOK_WRITER=<!-- FILL:writer --> lab-notebook emit \
   --context "<!-- FILL:context -->" --type <TYPE> \
   --issue "<STORY_ID>" --branch "<!-- FILL:branch -->" \
   [--files_changed "file1,file2"] [--commit "SHA"] [--pr "URL"] \

--- a/shared/ralph-lib.sh
+++ b/shared/ralph-lib.sh
@@ -140,8 +140,98 @@ archive_previous_run() {
     fi
 }
 
+# --- One-time upgrade shim: OLD layout -> .ralph/ layout ---
+# Older installs scattered ralph state across the project root:
+#   ./.lnb/            the notebook        -> .ralph/.lnb
+#   ./.lnb.env         pointer (abs path)  -> rewritten to point at .ralph/.lnb
+#   ./.ralph-last-branch  bare branch cursor -> .ralph/state.json
+#   ./archive/         old snapshots       -> .ralph/archive
+#
+# This migrates such a tree ONCE, in place, without data loss, and is a clean
+# no-op on every later run. It runs at the top of ensure_notebook (BEFORE the
+# fresh-init check) so a fresh `.ralph/.lnb` is never created over a user's
+# existing history. Both runners reach it via ensure_notebook.
+#
+# Each step is independently guarded on "new target absent", so a tree that was
+# only partially migrated by an interrupted run converges safely: no step ever
+# double-moves or clobbers, and the whole helper is safe under set -euo pipefail.
+# It MUST NOT invoke git (ralph is git-optional and must work in a plain
+# non-git dir); when it migrates files that may be git-tracked it only PRINTS
+# guidance to stderr, leaving untracking to the user.
+migrate_old_layout() {
+    # Nothing to do unless at least one OLD-layout artifact is present. Avoids
+    # creating a stray .ralph/ on fresh projects (the shim must be inert there).
+    if [[ ! -e ./.lnb && ! -e ./.lnb.env && ! -e ./.ralph-last-branch && ! -e ./archive ]]; then
+        return 0
+    fi
+
+    mkdir -p .ralph
+    local migrated_tracked=0
+
+    # 1) Notebook: MOVE ./.lnb -> .ralph/.lnb (never re-init over it). Guarded so
+    #    a second run (target present) is a no-op and a half-migrated tree where
+    #    .ralph/.lnb already exists is left untouched.
+    if [[ -d ./.lnb && ! -e .ralph/.lnb ]]; then
+        mv ./.lnb .ralph/.lnb
+        # Rewrite the root pointer so LAB_NOTEBOOK_DIR is the new ABSOLUTE path.
+        # Match the format `lab-notebook init` writes: an `export
+        # LAB_NOTEBOOK_DIR=<abs>` line (lab-notebook parses only that key). We
+        # surgically replace just that line in an existing .lnb.env (preserving
+        # the comment + any LAB_NOTEBOOK_WRITER line); if there's no such line
+        # or no file, (re)write the pointer in the canonical init format.
+        local abs_nb
+        abs_nb="$(cd .ralph/.lnb && pwd)"
+        if [[ -f ./.lnb.env ]] && grep -q '^[[:space:]]*\(export[[:space:]]\+\)\?LAB_NOTEBOOK_DIR=' ./.lnb.env; then
+            local tmp_env
+            tmp_env="$(mktemp ./.lnb.env.XXXXXX)"
+            sed "s|^\([[:space:]]*\(export[[:space:]]\+\)\?\)LAB_NOTEBOOK_DIR=.*|\1LAB_NOTEBOOK_DIR=$abs_nb|" \
+                ./.lnb.env > "$tmp_env"
+            mv "$tmp_env" ./.lnb.env
+        else
+            printf '# Project-local lab-notebook configuration\nexport LAB_NOTEBOOK_DIR=%s\n' \
+                "$abs_nb" > ./.lnb.env
+        fi
+        echo "Migrated notebook: ./.lnb -> .ralph/.lnb (pointer .lnb.env -> $abs_nb)" >&2
+    fi
+
+    # 2) Cursor: translate ./.ralph-last-branch (a bare branch string) into
+    #    .ralph/state.json in the LANDED schema, then remove the old file.
+    #    Guarded so we never overwrite an existing state.json.
+    if [[ -f ./.ralph-last-branch && ! -e .ralph/state.json ]]; then
+        local old_branch now
+        old_branch="$(tr -d '\n' < ./.ralph-last-branch | sed 's/[[:space:]]*$//')"
+        now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+        jq -n \
+            --arg branch "$old_branch" \
+            --arg last_run "$now" \
+            '{branch: $branch, last_run: $last_run, completed_branch: null}' \
+            > .ralph/state.json
+        rm -f ./.ralph-last-branch
+        migrated_tracked=1
+        echo "Migrated cursor: ./.ralph-last-branch (branch '$old_branch') -> .ralph/state.json" >&2
+    fi
+
+    # 3) Archive: MOVE ./archive -> .ralph/archive. Guarded on target absent.
+    if [[ -d ./archive && ! -e .ralph/archive ]]; then
+        mv ./archive .ralph/archive
+        migrated_tracked=1
+        echo "Migrated archive: ./archive -> .ralph/archive" >&2
+    fi
+
+    # If we moved files that the user may have committed (the OLD cursor /
+    # archive leaked into git), point them at the manual cleanup. We NEVER run
+    # git ourselves — ralph is git-optional and untracking is the user's call.
+    if [[ "$migrated_tracked" -eq 1 ]]; then
+        echo "If these were tracked in git, run: git rm --cached .ralph-last-branch archive" >&2
+        echo "  (drops the now-migrated, gitignored files from the index; safe to skip in a non-git dir)" >&2
+    fi
+}
+
 # --- Notebook helpers ---
 ensure_notebook() {
+    # Migrate any OLD-layout state in place BEFORE the fresh-init check, so we
+    # never init a fresh empty .ralph/.lnb over a user's existing notebook.
+    migrate_old_layout
     if [[ ! -d "$NOTEBOOK_DIR" ]]; then
         # `lab-notebook init .ralph` forces a `/.lnb` leaf and writes a root
         # .lnb.env pointing at it with an ABSOLUTE path, plus the notebook's

--- a/shared/ralph-lib.sh
+++ b/shared/ralph-lib.sh
@@ -31,6 +31,9 @@ read_task_meta() {
 # "ralph/" then turn any remaining "/" into "-". E.g. ralph/foo -> foo,
 # feature/x -> feature-x, main -> main. ONE definition shared by both the
 # archive-folder name and the notebook writer id, so they can't drift.
+# NOTE: not injective — `ralph/foo` and `foo` both slug to `foo` (likewise
+# `ralph/a/b` and `a-b`), so two branches differing only by a leading `ralph/`
+# (or `/` vs `-`) share an archive folder and, in shared-notebook mode, a writer.
 branch_slug() {
     echo "$1" | sed 's|^ralph/||; s|/|-|g'
 }
@@ -169,29 +172,36 @@ migrate_old_layout() {
     local migrated_tracked=0
 
     # 1) Notebook: MOVE ./.lnb -> .ralph/.lnb (never re-init over it). Guarded so
-    #    a second run (target present) is a no-op and a half-migrated tree where
-    #    .ralph/.lnb already exists is left untouched.
+    #    a second run (target present) is a no-op. The pointer is reconciled
+    #    separately below so an interrupted move (moved, but died before the
+    #    pointer rewrite) still converges on a later run.
     if [[ -d ./.lnb && ! -e .ralph/.lnb ]]; then
-        mv ./.lnb .ralph/.lnb
-        # Rewrite the root pointer so LAB_NOTEBOOK_DIR is the new ABSOLUTE path.
-        # Match the format `lab-notebook init` writes: an `export
-        # LAB_NOTEBOOK_DIR=<abs>` line (lab-notebook parses only that key). We
-        # surgically replace just that line in an existing .lnb.env (preserving
-        # the comment + any LAB_NOTEBOOK_WRITER line); if there's no such line
-        # or no file, (re)write the pointer in the canonical init format.
         local abs_nb
+        mv ./.lnb .ralph/.lnb
         abs_nb="$(cd .ralph/.lnb && pwd)"
-        if [[ -f ./.lnb.env ]] && grep -q '^[[:space:]]*\(export[[:space:]]\+\)\?LAB_NOTEBOOK_DIR=' ./.lnb.env; then
-            local tmp_env
-            tmp_env="$(mktemp ./.lnb.env.XXXXXX)"
-            sed "s|^\([[:space:]]*\(export[[:space:]]\+\)\?\)LAB_NOTEBOOK_DIR=.*|\1LAB_NOTEBOOK_DIR=$abs_nb|" \
-                ./.lnb.env > "$tmp_env"
-            mv "$tmp_env" ./.lnb.env
-        else
-            printf '# Project-local lab-notebook configuration\nexport LAB_NOTEBOOK_DIR=%s\n' \
-                "$abs_nb" > ./.lnb.env
-        fi
+        write_notebook_pointer "$abs_nb"
         echo "Migrated notebook: ./.lnb -> .ralph/.lnb (pointer .lnb.env -> $abs_nb)" >&2
+    elif [[ -d ./.lnb && -d .ralph/.lnb ]]; then
+        # Both old and new notebooks exist — an earlier interrupted run or manual
+        # state stranded ./.lnb. We never auto-merge or delete history; warn
+        # loudly so the user reconciles, otherwise ./.lnb is silently ignored.
+        echo "WARNING: both ./.lnb and .ralph/.lnb exist; ./.lnb is left in place and its history is NOT used." >&2
+        echo "  Reconcile manually, then 'rm -rf ./.lnb' once you've confirmed .ralph/.lnb is the notebook to keep." >&2
+    fi
+
+    # Reconcile the .lnb.env pointer even when the MOVE happened in a prior
+    # (possibly interrupted) run that died before rewriting it: if the notebook
+    # lives at .ralph/.lnb but the pointer resolves to a missing dir, repoint it.
+    # Idempotent — a pointer already resolving to a real dir is left untouched,
+    # so a deliberate custom LAB_NOTEBOOK_DIR is never clobbered.
+    if [[ -d .ralph/.lnb && -f ./.lnb.env ]]; then
+        local abs_nb cur_dir
+        abs_nb="$(cd .ralph/.lnb && pwd)"
+        cur_dir="$(sed -n 's|^[[:space:]]*\(export[[:space:]]\+\)\?LAB_NOTEBOOK_DIR=\(.*\)|\2|p' ./.lnb.env | head -1)"
+        if [[ -n "$cur_dir" && ! -d "$cur_dir" ]]; then
+            write_notebook_pointer "$abs_nb"
+            echo "Reconciled stale notebook pointer: .lnb.env -> $abs_nb" >&2
+        fi
     fi
 
     # 2) Cursor: translate ./.ralph-last-branch (a bare branch string) into
@@ -224,6 +234,31 @@ migrate_old_layout() {
     if [[ "$migrated_tracked" -eq 1 ]]; then
         echo "If these were tracked in git, run: git rm --cached .ralph-last-branch archive" >&2
         echo "  (drops the now-migrated, gitignored files from the index; safe to skip in a non-git dir)" >&2
+    fi
+}
+
+# Write/replace the LAB_NOTEBOOK_DIR line in ./.lnb.env so it points at $1 (an
+# absolute notebook dir), matching the `export LAB_NOTEBOOK_DIR=<abs>` format
+# `lab-notebook init` writes (lab-notebook parses only that key). Surgically
+# replaces just that line if present (preserving the comment + any
+# LAB_NOTEBOOK_WRITER line); otherwise (re)writes the pointer in canonical init
+# format. The replacement is escaped so a `\`, `&`, or the `|` sed delimiter in
+# the path can't corrupt the expression.
+write_notebook_pointer() {
+    local abs_nb="$1" esc tmp_env
+    if [[ -f ./.lnb.env ]] && grep -q '^[[:space:]]*\(export[[:space:]]\+\)\?LAB_NOTEBOOK_DIR=' ./.lnb.env; then
+        # Escape sed-replacement metacharacters; backslashes FIRST so the ones we
+        # add below aren't doubled again.
+        esc=${abs_nb//\\/\\\\}
+        esc=${esc//&/\\&}
+        esc=${esc//|/\\|}
+        tmp_env="$(mktemp ./.lnb.env.XXXXXX)"
+        sed "s|^\([[:space:]]*\(export[[:space:]]\+\)\?\)LAB_NOTEBOOK_DIR=.*|\1LAB_NOTEBOOK_DIR=$esc|" \
+            ./.lnb.env > "$tmp_env"
+        mv "$tmp_env" ./.lnb.env
+    else
+        printf '# Project-local lab-notebook configuration\nexport LAB_NOTEBOOK_DIR=%s\n' \
+            "$abs_nb" > ./.lnb.env
     fi
 }
 

--- a/shared/ralph-lib.sh
+++ b/shared/ralph-lib.sh
@@ -1,11 +1,24 @@
 # Shared helpers for ralph.sh and ralph-prep.sh.
 # Source this file after defining: SCRIPT_DIR, SHARED_DIR, PROMPT_FILE,
-# TASK_FILE, NOTEBOOK_DIR, CONTEXT, ARCHIVE_DIR, LAST_BRANCH_FILE. The
+# TASK_FILE, NOTEBOOK_DIR, CONTEXT, ARCHIVE_DIR, STATE_FILE. The
 # functions below also use BRANCH and PROJECT, which callers typically
 # resolve via read_task_meta after sourcing.
 #
 # SHARED_DIR must point at the repo's shared/ directory so ensure_notebook
 # can locate coding-dev.yaml. Both runners set it as "$SCRIPT_DIR/../shared".
+#
+# STATE_FILE is the gitignored batch cursor (.ralph/state.json). It is the
+# successor to the leaking flat-file branch cursor it replaces. Schema
+# (minimal, jq-friendly):
+#   {
+#     "branch":           "<current branch from tasks.json>",
+#     "last_run":         "<ISO 8601 timestamp of the last run>",
+#     "completed_branch": "<branch whose all-green batch was recorded
+#                          complete, or null if none>"
+#   }
+# `branch` is the archive cursor; `completed_branch` gates the refuse-respin
+# guard (see batch_already_complete). The notebook self-archives, so no
+# notebook copy is ever made.
 
 # --- Read task file metadata ---
 read_task_meta() {
@@ -13,11 +26,82 @@ read_task_meta() {
     jq -r ".$key // empty" "$TASK_FILE" 2>/dev/null || echo ""
 }
 
+# --- State (.ralph/state.json) helpers ---
+# Read a single field from the state cursor. Echoes "" when the file is
+# missing, empty, malformed, or the field is absent/null.
+read_state() {
+    local key="$1"
+    [[ -s "$STATE_FILE" ]] || { echo ""; return; }
+    jq -r ".$key // empty" "$STATE_FILE" 2>/dev/null || echo ""
+}
+
+# Write the run cursor (branch + last_run) WITHOUT disturbing the recorded
+# completion marker. Always preserves any existing completed_branch so the
+# refuse-respin guard survives ordinary same-branch re-runs and archives.
+write_state_cursor() {
+    local prev_completed
+    prev_completed=$(read_state "completed_branch")
+    mkdir -p "$(dirname "$STATE_FILE")"
+    local now
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    jq -n \
+        --arg branch "${BRANCH:-}" \
+        --arg last_run "$now" \
+        --arg completed "$prev_completed" \
+        '{branch: $branch, last_run: $last_run,
+          completed_branch: (if $completed == "" then null else $completed end)}' \
+        > "$STATE_FILE"
+}
+
+# Record the current branch's batch as complete (sets completed_branch to the
+# current BRANCH). Refreshes last_run; keeps the branch cursor pointing at the
+# current branch.
+record_batch_complete() {
+    mkdir -p "$(dirname "$STATE_FILE")"
+    local now
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+    jq -n \
+        --arg branch "${BRANCH:-}" \
+        --arg last_run "$now" \
+        --arg completed "${BRANCH:-}" \
+        '{branch: $branch, last_run: $last_run,
+          completed_branch: (if $completed == "" then null else $completed end)}' \
+        > "$STATE_FILE"
+}
+
+# --- Completion / refuse-respin support ---
+# True (exit 0) iff every story in TASK_FILE has passes:true and there is at
+# least one story.
+tasks_all_pass() {
+    [[ -f "$TASK_FILE" ]] || return 1
+    local total passing
+    total=$(jq '[.stories[]?] | length' "$TASK_FILE" 2>/dev/null || echo 0)
+    [[ "$total" -gt 0 ]] || return 1
+    passing=$(jq '[.stories[]? | select(.passes == true)] | length' "$TASK_FILE" 2>/dev/null || echo 0)
+    [[ "$passing" == "$total" ]]
+}
+
+# True (exit 0) iff the current branch's batch is all-green AND was recorded
+# complete in state.json. This is the refuse-respin condition.
+batch_already_complete() {
+    [[ -n "${BRANCH:-}" ]] || return 1
+    local completed
+    completed=$(read_state "completed_branch")
+    [[ "$completed" == "$BRANCH" ]] || return 1
+    tasks_all_pass
+}
+
 # --- Archive support ---
+# Archive trigger (resolved spec rule): archive iff a recorded cursor
+# (STATE_FILE) exists, is non-empty, AND its `branch` differs from the current
+# BRANCH. On first run (no cursor) record the cursor and archive nothing; on a
+# same-branch re-run, archive nothing. A MISSING state.json means "first run,
+# archive nothing" — never "transition, archive". On a real transition we
+# snapshot ONLY tasks.json (the notebook self-archives by context).
 archive_previous_run() {
-    if [[ -f "$TASK_FILE" && -f "$LAST_BRANCH_FILE" ]]; then
+    if [[ -f "$TASK_FILE" && -s "$STATE_FILE" ]]; then
         local last_branch
-        last_branch=$(cat "$LAST_BRANCH_FILE" 2>/dev/null || echo "")
+        last_branch=$(read_state "branch")
         if [[ -n "$BRANCH" && -n "$last_branch" && "$BRANCH" != "$last_branch" ]]; then
             local date_str folder_name archive_folder
             date_str=$(date +%Y-%m-%d)
@@ -27,14 +111,13 @@ archive_previous_run() {
             echo "Archiving previous run: $last_branch" >&2
             mkdir -p "$archive_folder"
             cp "$TASK_FILE" "$archive_folder/"
-            if [[ -d "$NOTEBOOK_DIR" ]]; then
-                cp -r "$NOTEBOOK_DIR" "$archive_folder/"
-            fi
-            echo "  Archived to: $archive_folder" >&2
+            echo "  Archived to: $archive_folder (tasks.json only)" >&2
         fi
     fi
+    # Always (re)record the run cursor so the next run can detect a transition.
+    # Preserves any existing completed_branch marker.
     if [[ -n "$BRANCH" ]]; then
-        echo "$BRANCH" > "$LAST_BRANCH_FILE"
+        write_state_cursor
     fi
 }
 

--- a/shared/ralph-lib.sh
+++ b/shared/ralph-lib.sh
@@ -41,19 +41,13 @@ archive_previous_run() {
 # --- Notebook helpers ---
 ensure_notebook() {
     if [[ ! -d "$NOTEBOOK_DIR" ]]; then
-        # lab-notebook init always creates a `.lnb` subfolder in cwd and
-        # loads the schema from --template-path directly, so no separate
-        # cp + rebuild step is needed.
-        lab-notebook init --template-path "$SHARED_DIR/coding-dev.yaml" >/dev/null
-
-        # Rename if the caller wants a non-default notebook dir, and
-        # patch .lnb.env so lab-notebook calls still find the notebook.
-        if [[ "$NOTEBOOK_DIR" != ".lnb" && -d ".lnb" && ! -d "$NOTEBOOK_DIR" ]]; then
-            mv .lnb "$NOTEBOOK_DIR"
-            if [[ -f .lnb.env ]]; then
-                sed -i.bak "s|/\\.lnb$|/$NOTEBOOK_DIR|" .lnb.env && rm -f .lnb.env.bak
-            fi
-        fi
+        # `lab-notebook init .ralph` forces a `/.lnb` leaf and writes a root
+        # .lnb.env pointing at it with an ABSOLUTE path, plus the notebook's
+        # own .gitignore — all in one call. That lands the notebook directly
+        # at .ralph/.lnb (the NOTEBOOK_DIR default), so no separate mv + sed
+        # patch of .lnb.env is needed.
+        mkdir -p .ralph
+        lab-notebook init .ralph --template-path "$SHARED_DIR/coding-dev.yaml" >/dev/null
 
         echo "Initialized notebook at $NOTEBOOK_DIR" >&2
     fi

--- a/shared/ralph-lib.sh
+++ b/shared/ralph-lib.sh
@@ -26,6 +26,25 @@ read_task_meta() {
     jq -r ".$key // empty" "$TASK_FILE" 2>/dev/null || echo ""
 }
 
+# --- Branch slug + writer identity ---
+# Normalize a branch name into a filesystem-safe slug: strip a leading
+# "ralph/" then turn any remaining "/" into "-". E.g. ralph/foo -> foo,
+# feature/x -> feature-x, main -> main. ONE definition shared by both the
+# archive-folder name and the notebook writer id, so they can't drift.
+branch_slug() {
+    echo "$1" | sed 's|^ralph/||; s|/|-|g'
+}
+
+# Per-loop notebook writer id, derived from BRANCH alone so it is identical
+# between both runners (byte-identical prompt contract) and reproducible from
+# BRANCH for the prompt-diff test. Defaults to "main" (same as build_prompt's
+# branch default). E.g. ralph/foo -> ralph-foo, ralph/smoke-test ->
+# ralph-smoke-test, feature/x -> ralph-feature-x, <unset> -> ralph-main.
+# Set as a PROCESS ENV VAR on the lab-notebook emit call, never in .lnb.env.
+notebook_writer() {
+    echo "ralph-$(branch_slug "${BRANCH:-main}")"
+}
+
 # --- State (.ralph/state.json) helpers ---
 # Read a single field from the state cursor. Echoes "" when the file is
 # missing, empty, malformed, or the field is absent/null.
@@ -105,7 +124,7 @@ archive_previous_run() {
         if [[ -n "$BRANCH" && -n "$last_branch" && "$BRANCH" != "$last_branch" ]]; then
             local date_str folder_name archive_folder
             date_str=$(date +%Y-%m-%d)
-            folder_name=$(echo "$last_branch" | sed 's|^ralph/||; s|/|-|g')
+            folder_name=$(branch_slug "$last_branch")
             archive_folder="$ARCHIVE_DIR/$date_str-$folder_name"
 
             echo "Archiving previous run: $last_branch" >&2
@@ -140,7 +159,12 @@ log_to_notebook() {
     local entry_type="$1"
     local message="$2"
     if command -v lab-notebook &>/dev/null && [[ -d "$NOTEBOOK_DIR" ]]; then
-        LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook emit \
+        # Attribute the entry to a per-loop writer (ralph-<branch-slug>), set as
+        # a process env var on the same command line so it is exported into the
+        # lab-notebook subprocess. This keeps several worktrees/loops pointed at
+        # one shared --notebook contention-free (per-writer JSONL).
+        LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" LAB_NOTEBOOK_WRITER="$(notebook_writer)" \
+            lab-notebook emit \
             --context "$CONTEXT" --type "$entry_type" \
             --branch "${BRANCH:-}" --tags "ralph-harness" \
             "$message" 2>/dev/null || true
@@ -170,10 +194,13 @@ build_prompt() {
     local prompt
     prompt=$(cat "$PROMPT_FILE")
 
-    # Replace FILL markers
+    # Replace FILL markers. The writer is derived from BRANCH alone (same as the
+    # runner's log_to_notebook), so both runners render the identical value and
+    # the byte-identical prompt contract holds.
     prompt="${prompt//<!-- FILL:context -->/$CONTEXT}"
     prompt="${prompt//<!-- FILL:notebook_dir -->/$NOTEBOOK_DIR}"
     prompt="${prompt//<!-- FILL:branch -->/${BRANCH:-main}}"
+    prompt="${prompt//<!-- FILL:writer -->/$(notebook_writer)}"
     prompt="${prompt//<!-- FILL:tasks -->/$tasks_content}"
     prompt="${prompt//<!-- FILL:recent_history -->/$history}"
 

--- a/skill/SKILL.md.template
+++ b/skill/SKILL.md.template
@@ -74,7 +74,7 @@ For `i` in `1..max-iterations`:
 
    Append `--prompt <prompt>` only if the user supplied one in Setup step 1; otherwise omit the flag so `ralph-prep.sh` uses its own default (`shared/PROMPT.md`).
 
-   Pass the same `N` you parsed in Setup so the start log entry records the cap alongside the iteration number (matches `cc-headless/ralph.sh`'s log format). `ralph-prep.sh` writes the filled prompt to `RALPH-PROMPT.md` in the project directory (the cwd) and prints only a one-line status to stdout — it does **not** print the prompt. Do not capture or hold the prompt; it never enters your context. Just confirm the Bash call succeeded.
+   Pass the same `N` you parsed in Setup so the start log entry records the cap alongside the iteration number (matches `cc-headless/ralph.sh`'s log format). `ralph-prep.sh` writes the filled prompt to `.ralph/prompt.md` in the project directory (the cwd) and prints only a one-line status to stdout — it does **not** print the prompt. Do not capture or hold the prompt; it never enters your context. Just confirm the Bash call succeeded.
 
 2. **Spawn the worker.** Call (the prompt is a fixed string — the subagent reads the real instructions from the file):
 
@@ -82,7 +82,7 @@ For `i` in `1..max-iterations`:
    Agent(
        subagent_type="general-purpose",
        description="ralph iteration i",
-       prompt="Read ./RALPH-PROMPT.md in the current working directory and follow its instructions exactly. If that file is missing or empty, stop and report it instead of proceeding."
+       prompt="Read .ralph/prompt.md in the current working directory and follow its instructions exactly. If that file is missing or empty, stop and report it instead of proceeding."
    )
    ```
 
@@ -122,10 +122,10 @@ For `i` in `1..max-iterations`:
 
 ## Context budgeting
 
-The filled prompt (notebook context + full `tasks.json` + recent history) never enters the main session's context: `ralph-prep.sh` writes it to `RALPH-PROMPT.md` and the subagent reads it directly. Each iteration adds only the prep status line plus the subagent's final narration and promise marker — on the order of tens of tokens. Keep your own between-iteration narration to one short line (`"iteration i: DONE, continuing"`). Do not read `RALPH-PROMPT.md` yourself, do not summarize subagent output, do not re-read `tasks.json` yourself (`ralph-prep.sh` already folds it into the prompt file every iteration), do not print anything the user doesn't need.
+The filled prompt (notebook context + full `tasks.json` + recent history) never enters the main session's context: `ralph-prep.sh` writes it to `.ralph/prompt.md` and the subagent reads it directly. Each iteration adds only the prep status line plus the subagent's final narration and promise marker — on the order of tens of tokens. Keep your own between-iteration narration to one short line (`"iteration i: DONE, continuing"`). Do not read `.ralph/prompt.md` yourself, do not summarize subagent output, do not re-read `tasks.json` yourself (`ralph-prep.sh` already folds it into the prompt file every iteration), do not print anything the user doesn't need.
 
 ## Relationship to the headless runner
 
-The headless runner `@@RALPH_REPO@@/cc-headless/ralph.sh` shares `shared/ralph-lib.sh`, `shared/PROMPT.md`, `tasks.json`, and `.lnb/` state with this skill. A change to `shared/ralph-lib.sh` (e.g. `build_prompt`) affects both runners. `ralph-prep.sh` is used only by this skill — headless calls `build_prompt` directly and pipes the prompt to `claude -p`, whereas this skill has `ralph-prep.sh` write the prompt to `RALPH-PROMPT.md` for a fresh `Agent()` subagent to read.
+The headless runner `@@RALPH_REPO@@/cc-headless/ralph.sh` shares `shared/ralph-lib.sh`, `shared/PROMPT.md`, `tasks.json`, and `.lnb/` state with this skill. A change to `shared/ralph-lib.sh` (e.g. `build_prompt`) affects both runners. `ralph-prep.sh` is used only by this skill — headless calls `build_prompt` directly and pipes the prompt to `claude -p`, whereas this skill has `ralph-prep.sh` write the prompt to `.ralph/prompt.md` for a fresh `Agent()` subagent to read.
 
 $ARGUMENTS

--- a/skill/SKILL.md.template
+++ b/skill/SKILL.md.template
@@ -2,7 +2,7 @@
 name: ralph-lnb
 description: "Run the Ralph Wiggum autonomous code loop inside a Claude Code session. Use when the user types /ralph-lnb, or says 'run ralph', 'start the ralph loop', 'keep iterating on the tasks', or asks to work through tasks.json story-by-story. Each iteration spawns a fresh subagent to complete one story and logs progress to the lab notebook."
 user-invocable: true
-argument-hint: "[max-iterations N] [task-file FILE] [prompt FILE]"
+argument-hint: "[max-iterations N] [task-file FILE] [prompt FILE] [force]"
 ---
 
 <!-- Managed by ralph-wiggum-lnb install.sh — do not edit by hand. Re-run ./install.sh from the repo to regenerate. -->

--- a/skill/SKILL.md.template
+++ b/skill/SKILL.md.template
@@ -9,7 +9,7 @@ argument-hint: "[max-iterations N] [task-file FILE] [prompt FILE]"
 
 # Ralph Loop — Claude Code Session Skill
 
-This skill runs the ralph loop (one story per iteration, fresh subagent each time, logs to `.lnb/`) using the `Agent()` subagent tool inside the current Claude Code chat. It is the skill-based equivalent of `@@RALPH_REPO@@/cc-headless/ralph.sh`, which spawns `claude -p` per iteration instead.
+This skill runs the ralph loop (one story per iteration, fresh subagent each time, logs to `.ralph/.lnb`) using the `Agent()` subagent tool inside the current Claude Code chat. It is the skill-based equivalent of `@@RALPH_REPO@@/cc-headless/ralph.sh`, which spawns `claude -p` per iteration instead.
 
 The ralph repo this skill was generated from lives at:
 
@@ -115,9 +115,9 @@ For `i` in `1..max-iterations`:
 
    Report a 3-5 sentence summary to the user covering what each story accomplished.
 
-2. If the loop ended on `max-iterations`, report: `"Hit iteration cap (N). Stopped. Check .lnb/ for progress."`
+2. If the loop ended on `max-iterations`, report: `"Hit iteration cap (N). Stopped. Check .ralph/.lnb for progress."`
 
-3. If the loop ended on a missing marker, report: `"Iteration i returned without a promise marker. Stopped. Check .lnb/ for the blocker entry and the subagent's final message."`
+3. If the loop ended on a missing marker, report: `"Iteration i returned without a promise marker. Stopped. Check .ralph/.lnb for the blocker entry and the subagent's final message."`
 
 ## Stop conditions (summary)
 
@@ -131,6 +131,6 @@ The filled prompt (notebook context + full `tasks.json` + recent history) never 
 
 ## Relationship to the headless runner
 
-The headless runner `@@RALPH_REPO@@/cc-headless/ralph.sh` shares `shared/ralph-lib.sh`, `shared/PROMPT.md`, `tasks.json`, and `.lnb/` state with this skill. A change to `shared/ralph-lib.sh` (e.g. `build_prompt`) affects both runners. `ralph-prep.sh` is used only by this skill — headless calls `build_prompt` directly and pipes the prompt to `claude -p`, whereas this skill has `ralph-prep.sh` write the prompt to `.ralph/prompt.md` for a fresh `Agent()` subagent to read.
+The headless runner `@@RALPH_REPO@@/cc-headless/ralph.sh` shares `shared/ralph-lib.sh`, `shared/PROMPT.md`, `tasks.json`, and `.ralph/.lnb` state with this skill. A change to `shared/ralph-lib.sh` (e.g. `build_prompt`) affects both runners. `ralph-prep.sh` is used only by this skill — headless calls `build_prompt` directly and pipes the prompt to `claude -p`, whereas this skill has `ralph-prep.sh` write the prompt to `.ralph/prompt.md` for a fresh `Agent()` subagent to read.
 
 $ARGUMENTS

--- a/skill/SKILL.md.template
+++ b/skill/SKILL.md.template
@@ -26,6 +26,7 @@ Parse `$ARGUMENTS` as a whitespace-separated list of `key value` pairs. Supporte
 | `max-iterations` | `10` | Safety cap on the loop |
 | `task-file` | `tasks.json` | Path to the task file (relative to cwd) |
 | `prompt` | `@@RALPH_REPO@@/shared/PROMPT.md` | Custom prompt template. Omit to use the repo's shared template. |
+| `force` | *(off)* | Bare flag (no value). Re-spin even when this branch's all-green batch was already recorded complete in `.ralph/state.json`. Bypasses the refuse-respin guard only. |
 
 Everything else gets ignored. Examples of valid argument strings:
 
@@ -33,6 +34,7 @@ Everything else gets ignored. Examples of valid argument strings:
 - `max-iterations 5`
 - `max-iterations 3 task-file sprint.json`
 - `max-iterations 5 prompt ./custom-prompt.md`
+- `force` — re-spin a batch already recorded complete
 
 ## Prerequisites (verify before starting)
 
@@ -52,7 +54,7 @@ When invoked, the main session (you) must do the following. Do not deviate, do n
 
 ### Setup
 
-1. Parse `max-iterations`, `task-file`, and `prompt` from `$ARGUMENTS`. Apply the defaults above for anything unspecified. `prompt` is optional — if the user did not supply it, leave the variable unset and omit `--prompt` from the `ralph-prep.sh` call in Loop step 1.
+1. Parse `max-iterations`, `task-file`, `prompt`, and `force` from `$ARGUMENTS`. Apply the defaults above for anything unspecified. `prompt` is optional — if the user did not supply it, leave the variable unset and omit `--prompt` from the `ralph-prep.sh` call in Loop step 1. `force` is a bare flag (it takes no value) — note whether it appeared so you can append `--force` to the `ralph-prep.sh` call in Loop step 1.
 2. Derive the notebook context once, so every subsequent log call uses the same value:
 
    ```
@@ -69,12 +71,14 @@ For `i` in `1..max-iterations`:
 1. **Build the prompt.** Call:
 
    ```
-   Bash("@@RALPH_REPO@@/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>[ --prompt <prompt>]")
+   Bash("@@RALPH_REPO@@/cc/ralph-prep.sh --iteration i --max-iterations N --task-file <task-file>[ --prompt <prompt>][ --force]")
    ```
 
-   Append `--prompt <prompt>` only if the user supplied one in Setup step 1; otherwise omit the flag so `ralph-prep.sh` uses its own default (`shared/PROMPT.md`).
+   Append `--prompt <prompt>` only if the user supplied one in Setup step 1; otherwise omit the flag so `ralph-prep.sh` uses its own default (`shared/PROMPT.md`). Append `--force` only if the user passed `force` in Setup step 1.
 
-   Pass the same `N` you parsed in Setup so the start log entry records the cap alongside the iteration number (matches `cc-headless/ralph.sh`'s log format). `ralph-prep.sh` writes the filled prompt to `.ralph/prompt.md` in the project directory (the cwd) and prints only a one-line status to stdout — it does **not** print the prompt. Do not capture or hold the prompt; it never enters your context. Just confirm the Bash call succeeded.
+   Pass the same `N` you parsed in Setup so the start log entry records the cap alongside the iteration number (matches `cc-headless/ralph.sh`'s log format). `ralph-prep.sh` writes the filled prompt to `.ralph/prompt.md` in the project directory (the cwd) and prints only a one-line status to stdout — it does **not** print the prompt. Do not capture or hold the prompt; it never enters your context.
+
+   **Refuse-respin guard (G3):** `ralph-prep.sh` exits **3** (without writing a prompt) when this branch's batch is all-`passes:true` AND was already recorded complete in `.ralph/state.json`. On iteration 1, if the call exits 3, the batch is already finished — do **not** spawn a worker. Report its stderr message verbatim to the user and stop (skip the rest of the Loop and Post-loop). The user can re-spin with `/ralph-lnb force` (or edit `tasks.json` / start a new branch). Any other non-zero exit is a real error — report it and stop. On exit 0, confirm the Bash call succeeded and continue.
 
 2. **Spawn the worker.** Call (the prompt is a fixed string — the subagent reads the real instructions from the file):
 
@@ -91,6 +95,7 @@ For `i` in `1..max-iterations`:
 3. **Check the return.** Inspect the subagent's final message. **Check `ALL_DONE` first — `<promise>ALL_DONE</promise>` contains `<promise>DONE</promise>` as a substring, so the order is load-bearing.** (Same reason `cc-headless/ralph.sh`'s grep checks `ALL_DONE` before `DONE`.)
 
    - Contains `<promise>ALL_DONE</promise>`:
+     - Record the batch complete so a later re-spin of the all-green `tasks.json` is refused (mirrors `cc-headless/ralph.sh`, which records this inline on `ALL_DONE`): `Bash("@@RALPH_REPO@@/cc/ralph-prep.sh --task-file <task-file> --record-complete")`. This writes `completed_branch` into `.ralph/state.json` and exits without prepping a prompt.
      - Call `Bash("LAB_NOTEBOOK_DIR=<notebook> lab-notebook emit --context <context> --type done --tags ralph-harness 'ralph-lnb: all stories complete at iteration i'")` using the `<context>` derived in Setup step 2.
      - Break the loop. Go to "Post-loop".
    - Contains `<promise>DONE</promise>`:

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,26 @@ Exercises both modes so you can verify the `/ralph-lnb` skill and
   `start` entry is logged. Run with `bash tests/prompt-diff.sh` (exits 0 on
   pass; prints a diff and exits non-zero on divergence). Self-contained:
   uses its own `$TMPDIR` sandboxes and needs no install.
+- `archive.sh` — drives `cc/ralph-prep.sh` to assert the `.ralph/state.json`
+  cursor, the archive-on-branch-change trigger (snapshots only `tasks.json`,
+  never the notebook), and the refuse-respin guard (an all-green recorded
+  batch is refused with exit 3 unless `--force`). Run with
+  `bash tests/archive.sh` (exits 0 on pass).
+- `concurrency.sh` — proves the per-loop writer design: two loops on different
+  branches pointed at one shared notebook each emit, concurrently, under their
+  own `ralph-<branch>` writer, landing in distinct `entries/ralph-*.jsonl`
+  files with nothing lost. Run with `bash tests/concurrency.sh` (exits 0 on
+  pass; SKIPs cleanly if `lab-notebook` is not on `$PATH`).
+- `upgrade.sh` — exercises `migrate_old_layout`, the one-time shim that moves
+  an old root-scattered install (`./.lnb`, `./.lnb.env`, `./.ralph-last-branch`,
+  `./archive/`) under `.ralph/` without data loss and is a clean no-op
+  afterwards — both in isolation and end-to-end through `cc/ralph-prep.sh`.
+  Run with `bash tests/upgrade.sh` (exits 0 on pass).
+
+Run all four at once with
+`for t in prompt-diff archive concurrency upgrade; do bash "tests/$t.sh"; done`
+(each is self-contained and exits 0 on pass; `setup-sandbox.sh` is a scaffolder,
+not a pass/fail test, so it is deliberately excluded).
 
 Prerequisite: run `../install.sh` once from the repo so `ralph` is on
 `$PATH` and `/ralph-lnb` is registered as a Claude Code skill. If you

--- a/tests/README.md
+++ b/tests/README.md
@@ -42,7 +42,7 @@ absolute-path fallbacks you can use instead.
    ```
    cat hello.txt
    jq '.stories[].passes' tasks.json   # both should be true
-   ls .lnb/
+   ls .ralph/.lnb/
    ```
 
 ## Running headless

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,6 +9,12 @@ Exercises both modes so you can verify the `/ralph-lnb` skill and
 
 - `tasks.json` — 2-story fixture (create `hello.txt`, append a line)
 - `setup-sandbox.sh` — scaffolds a timestamped sandbox under `$TMPDIR`
+- `prompt-diff.sh` — exit-code regression test asserting the two runners
+  (`cc-headless/ralph.sh` and `cc/ralph-prep.sh`) build byte-identical
+  prompts, and that recent history is queried before the iteration's own
+  `start` entry is logged. Run with `bash tests/prompt-diff.sh` (exits 0 on
+  pass; prints a diff and exits non-zero on divergence). Self-contained:
+  uses its own `$TMPDIR` sandboxes and needs no install.
 
 Prerequisite: run `../install.sh` once from the repo so `ralph` is on
 `$PATH` and `/ralph-lnb` is registered as a Claude Code skill. If you

--- a/tests/archive.sh
+++ b/tests/archive.sh
@@ -157,7 +157,27 @@ assert_no_last_branch
 pass "batch refused with clear message (exit 3); --force re-spins it (exit 0)"
 
 ###############################################################################
-echo "== Assertion 5: no .ralph-last-branch anywhere in the sandbox =="
+echo "== Assertion 5: a partial batch is NOT refused even when recorded complete =="
+###############################################################################
+# completed_branch still equals BRANCH2 from Assertion 4, but batch_already_complete
+# ANDs tasks_all_pass — so flipping ONE story to passes:false must make a plain run
+# (no --force) prep normally and exit 0, never the refuse-respin exit 3.
+tmp="$(mktemp "$WORKROOT/tasks.XXXXXX")"
+jq '.stories[0].passes = false' tasks.json > "$tmp"; mv "$tmp" tasks.json
+[[ "$(jq -r '.completed_branch' "$STATE_FILE")" == "$BRANCH2" ]] \
+    || fail "precondition: completed_branch should still be '$BRANCH2' for this check"
+rm -f ".ralph/prompt.md"
+LOG="$WORKROOT/log5-partial"
+rc=0
+run_prep "$LOG" --iteration 1 || rc=$?
+[[ "$rc" -eq 0 ]] \
+    || fail "partial batch was refused (exit $rc); expected normal prep (exit 0): $(cat "$LOG")"
+[[ -f ".ralph/prompt.md" ]] || fail "partial-batch run did not write .ralph/prompt.md"
+assert_no_last_branch
+pass "partial batch preps normally (exit 0) despite completed_branch match"
+
+###############################################################################
+echo "== Assertion 6: no .ralph-last-branch anywhere in the sandbox =="
 ###############################################################################
 if find "$SANDBOX" -name '.ralph-last-branch' -print | grep -q .; then
     fail "a .ralph-last-branch file exists in the sandbox"

--- a/tests/archive.sh
+++ b/tests/archive.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# State-cursor + archive + refuse-respin regression test (handoff 05).
+#
+# Asserts the resolved archive-trigger rule and the G3 refuse-respin guard,
+# all driven through cc/ralph-prep.sh (the runnable bookkeeping entry point —
+# it triggers archive_previous_run, the refuse-respin guard, and the cursor
+# write without needing `claude` to run an agent):
+#
+#   1. First run (no cursor): records .ralph/state.json, archives NOTHING.
+#   2. Same-branch re-run: archives NOTHING (cursor unchanged branch).
+#   3. Different-branch run: snapshots ONLY tasks.json into
+#      .ralph/archive/<date>-<branch>/ — NO notebook copy.
+#   4. An all-green, recorded-complete batch is refused with a clear message;
+#      --force overrides it.
+#   5. No .ralph-last-branch is ever created (cursor fully migrated).
+#
+# Mechanics (mirrors tests/prompt-diff.sh / tests/setup-sandbox.sh):
+#   - Resolve the repo via BASH_SOURCE, never `which ralph` (the installed
+#     ralph may resolve to a different checkout).
+#   - Run in a throwaway $TMPDIR sandbox seeded with tests/tasks.json; clean up
+#     on exit. Works in a plain non-git dir (ralph is git-optional; nothing
+#     here invokes git).
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREP="$REPO_DIR/cc/ralph-prep.sh"
+
+WORKROOT="${TMPDIR:-/tmp}/ralph-archive-$(date +%Y%m%d-%H%M%S)-$$"
+mkdir -p "$WORKROOT"
+cleanup() { cd /; rm -rf "$WORKROOT"; }
+trap cleanup EXIT
+
+SANDBOX="$WORKROOT/sandbox"
+mkdir -p "$SANDBOX"
+cp "$REPO_DIR/tests/tasks.json" "$SANDBOX/tasks.json"
+cd "$SANDBOX"
+
+DATE_STR="$(date +%Y-%m-%d)"
+STATE_FILE=".ralph/state.json"
+
+pass() { echo "  OK: $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Run ralph-prep.sh; diagnostics+status go to $1 (a file), returns its exit
+# code (without tripping set -e). Used so we can inspect both exit code and
+# message text.
+run_prep() {
+    local logfile="$1"; shift
+    local rc=0
+    "$PREP" --task-file tasks.json "$@" >"$logfile" 2>&1 || rc=$?
+    return $rc
+}
+
+# Guard against a stray .ralph-last-branch anywhere in the sandbox.
+assert_no_last_branch() {
+    if find "$SANDBOX" -name '.ralph-last-branch' -print -quit | grep -q .; then
+        fail "a .ralph-last-branch file was created (cursor not migrated)"
+    fi
+}
+
+set_branch() {
+    local newbranch="$1" tmp
+    tmp="$(mktemp "$WORKROOT/tasks.XXXXXX")"
+    jq --arg b "$newbranch" '.branch = $b' tasks.json > "$tmp"
+    mv "$tmp" tasks.json
+}
+
+# tasks.json fixture starts on branch ralph/smoke-test.
+BRANCH1="ralph/smoke-test"
+BRANCH2="ralph/second-batch"
+
+###############################################################################
+echo "== Assertion 1: first run records state.json and archives nothing =="
+###############################################################################
+LOG="$WORKROOT/log1"
+run_prep "$LOG" --iteration 1 || fail "first run exited non-zero: $(cat "$LOG")"
+
+[[ -s "$STATE_FILE" ]] || fail "first run did not create $STATE_FILE"
+recorded_branch=$(jq -r '.branch' "$STATE_FILE")
+[[ "$recorded_branch" == "$BRANCH1" ]] \
+    || fail "state.json branch is '$recorded_branch', expected '$BRANCH1'"
+# Schema sanity: last_run present, completed_branch present (null on first run).
+[[ "$(jq -r 'has("last_run")' "$STATE_FILE")" == "true" ]] \
+    || fail "state.json missing last_run"
+[[ "$(jq -r '.completed_branch' "$STATE_FILE")" == "null" ]] \
+    || fail "first run should leave completed_branch null"
+[[ ! -d ".ralph/archive" ]] || fail "first run created an archive dir: $(ls -R .ralph/archive)"
+assert_no_last_branch
+pass "state.json recorded (branch=$BRANCH1, completed_branch=null), no archive"
+
+###############################################################################
+echo "== Assertion 2: same-branch re-run archives nothing =="
+###############################################################################
+LOG="$WORKROOT/log2"
+run_prep "$LOG" --iteration 2 || fail "same-branch re-run exited non-zero: $(cat "$LOG")"
+[[ ! -d ".ralph/archive" ]] || fail "same-branch re-run created an archive dir: $(ls -R .ralph/archive)"
+[[ "$(jq -r '.branch' "$STATE_FILE")" == "$BRANCH1" ]] \
+    || fail "same-branch re-run changed the recorded branch"
+assert_no_last_branch
+pass "no archive dir after same-branch re-run"
+
+###############################################################################
+echo "== Assertion 3: branch change snapshots ONLY tasks.json, no notebook copy =="
+###############################################################################
+set_branch "$BRANCH2"
+LOG="$WORKROOT/log3"
+run_prep "$LOG" --iteration 1 || fail "branch-change run exited non-zero: $(cat "$LOG")"
+
+# Old branch (ralph/smoke-test) folds 'ralph/' off and '/'->'-': "smoke-test".
+ARCHIVE_FOLDER=".ralph/archive/$DATE_STR-smoke-test"
+[[ -d "$ARCHIVE_FOLDER" ]] || fail "branch change did not create $ARCHIVE_FOLDER (have: $(ls -R .ralph/archive 2>/dev/null))"
+[[ -f "$ARCHIVE_FOLDER/tasks.json" ]] || fail "archive folder has no tasks.json snapshot"
+
+# Snapshot must be tasks.json ONLY — no notebook (.lnb) copied in.
+extra=$(find "$ARCHIVE_FOLDER" -mindepth 1 ! -name 'tasks.json' -print)
+[[ -z "$extra" ]] || fail "archive folder contains more than tasks.json (notebook copied?): $extra"
+if find "$ARCHIVE_FOLDER" -name '.lnb' -o -name '*.jsonl' | grep -q .; then
+    fail "notebook artifacts found inside the archive folder"
+fi
+# Cursor now advanced to the new branch.
+[[ "$(jq -r '.branch' "$STATE_FILE")" == "$BRANCH2" ]] \
+    || fail "cursor did not advance to '$BRANCH2' after transition"
+assert_no_last_branch
+pass "snapshot is tasks.json only under $ARCHIVE_FOLDER; cursor advanced to $BRANCH2"
+
+###############################################################################
+echo "== Assertion 4: all-green recorded-complete batch is refused; --force overrides =="
+###############################################################################
+# Flip every story to passes:true and record the batch complete.
+tmp="$(mktemp "$WORKROOT/tasks.XXXXXX")"
+jq '.stories |= map(.passes = true)' tasks.json > "$tmp"; mv "$tmp" tasks.json
+run_prep "$WORKROOT/log4-record" --record-complete \
+    || fail "--record-complete exited non-zero: $(cat "$WORKROOT/log4-record")"
+[[ "$(jq -r '.completed_branch' "$STATE_FILE")" == "$BRANCH2" ]] \
+    || fail "--record-complete did not set completed_branch to '$BRANCH2'"
+
+# A plain run must now be refused with exit 3 and a clear message. Clear any
+# prompt left by an earlier (non-refused) run so we can prove the refused run
+# does not write one.
+rm -f ".ralph/prompt.md"
+LOG="$WORKROOT/log4-refuse"
+rc=0
+run_prep "$LOG" --iteration 1 || rc=$?
+[[ "$rc" -eq 3 ]] || fail "expected refuse-respin exit 3, got $rc; output: $(cat "$LOG")"
+grep -qi "already complete" "$LOG" \
+    || fail "refuse-respin message unclear (no 'already complete'): $(cat "$LOG")"
+# A refused run must NOT have written a prompt.
+[[ ! -f ".ralph/prompt.md" ]] || fail "refused run still wrote .ralph/prompt.md"
+
+# --force overrides the guard: it preps a prompt and exits 0.
+LOG="$WORKROOT/log4-force"
+run_prep "$LOG" --iteration 1 --force \
+    || fail "--force run exited non-zero (guard not bypassed): $(cat "$LOG")"
+[[ -f ".ralph/prompt.md" ]] || fail "--force run did not write .ralph/prompt.md"
+assert_no_last_branch
+pass "batch refused with clear message (exit 3); --force re-spins it (exit 0)"
+
+###############################################################################
+echo "== Assertion 5: no .ralph-last-branch anywhere in the sandbox =="
+###############################################################################
+if find "$SANDBOX" -name '.ralph-last-branch' -print | grep -q .; then
+    fail "a .ralph-last-branch file exists in the sandbox"
+fi
+pass "no .ralph-last-branch created at any point"
+
+echo ""
+echo "PASS: state cursor, archive trigger, and refuse-respin guard all hold."

--- a/tests/concurrency.sh
+++ b/tests/concurrency.sh
@@ -9,6 +9,12 @@ set -euo pipefail
 # contention-free — both entries persist in distinct entries/ralph-*.jsonl
 # files and both are returned by a single `lab-notebook sql`, with nothing lost.
 #
+# To exercise a REAL race (not just sequential disambiguation), the two emits
+# run as backgrounded jobs and we `wait` for both: the writers genuinely append
+# at the same time. This is deterministically safe precisely because per-writer
+# isolation gives each its OWN entries/ralph-<branch>.jsonl — there is no shared
+# file for them to clobber, so concurrent appends never collide.
+#
 # This is the "opt-in --notebook shared mode" surface: there is no special
 # flag; both runners already accept --notebook <shared-path>, and writer
 # disambiguation (LAB_NOTEBOOK_WRITER=ralph-<branch>, set by log_to_notebook)
@@ -61,10 +67,17 @@ emit_as() {
 }
 
 ###############################################################################
-echo "== Two loops on different branches emit into ONE shared notebook =="
+echo "== Two loops on different branches emit CONCURRENTLY into ONE shared notebook =="
 ###############################################################################
-emit_as "ralph/loop-a" "loop A: entry from branch a"
-emit_as "ralph/loop-b" "loop B: entry from branch b"
+# Background BOTH emits and wait for the pair, so the two writers append at the
+# same time — a genuine race. Each runs in its own subshell, so emit_as's local
+# BRANCH/CONTEXT for one loop can't leak into the other. Per-writer isolation
+# (distinct entries/ralph-<branch>.jsonl) makes this deterministically safe.
+emit_as "ralph/loop-a" "loop A: entry from branch a" & pid_a=$!
+emit_as "ralph/loop-b" "loop B: entry from branch b" & pid_b=$!
+# wait per-pid so a failed background emit fails the test (bare `wait` swallows it).
+wait "$pid_a" || fail "concurrent emit for loop-a failed"
+wait "$pid_b" || fail "concurrent emit for loop-b failed"
 
 ENTRIES_DIR="$NOTEBOOK_DIR/entries"
 [[ -d "$ENTRIES_DIR" ]] || fail "no entries/ dir under shared notebook ($ENTRIES_DIR)"
@@ -112,4 +125,4 @@ $ROWS"
 pass "single sql returns both writers' entries (count=2); no lost entries"
 
 echo ""
-echo "PASS: shared-notebook per-writer concurrency holds."
+echo "PASS: shared-notebook concurrent writes are contention-free (per-writer)."

--- a/tests/concurrency.sh
+++ b/tests/concurrency.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Shared-notebook concurrency test (handoff 06).
+#
+# Proves the per-loop writer design (handoff 06): two loops on DIFFERENT
+# branches pointed at ONE shared notebook each emit under their own
+# ralph-<branch> writer, so per-writer JSONL keeps concurrent writes
+# contention-free — both entries persist in distinct entries/ralph-*.jsonl
+# files and both are returned by a single `lab-notebook sql`, with nothing lost.
+#
+# This is the "opt-in --notebook shared mode" surface: there is no special
+# flag; both runners already accept --notebook <shared-path>, and writer
+# disambiguation (LAB_NOTEBOOK_WRITER=ralph-<branch>, set by log_to_notebook)
+# does the rest. Here we drive log_to_notebook directly via ralph-lib.sh so the
+# test exercises the exact code path the runners use, without needing `claude`.
+#
+# Mechanics (mirrors tests/setup-sandbox.sh / tests/prompt-diff.sh):
+#   - Resolve the repo via BASH_SOURCE, never `which ralph` (the installed
+#     ralph may resolve to a different checkout).
+#   - Throwaway $TMPDIR workroot, cleaned up on exit. Works in a plain non-git
+#     dir (ralph is git-optional; nothing here invokes git).
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v lab-notebook &>/dev/null; then
+    echo "SKIP: lab-notebook not on PATH; cannot run concurrency test." >&2
+    exit 0
+fi
+
+WORKROOT="${TMPDIR:-/tmp}/ralph-concurrency-$(date +%Y%m%d-%H%M%S)-$$"
+mkdir -p "$WORKROOT"
+cleanup() { cd /; rm -rf "$WORKROOT"; }
+trap cleanup EXIT
+
+pass() { echo "  OK: $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# One shared notebook lives under $WORKROOT/shared/.ralph/.lnb. Both loops point
+# their NOTEBOOK_DIR at it — this is the --notebook <shared-path> pattern.
+SHARED_ROOT="$WORKROOT/shared"
+mkdir -p "$SHARED_ROOT/.ralph"
+cd "$SHARED_ROOT"
+SHARED_DIR="$REPO_DIR/shared"
+NOTEBOOK_DIR="$SHARED_ROOT/.ralph/.lnb"
+
+# Initialize the shared notebook once (matches ensure_notebook's init call).
+lab-notebook init .ralph --template-path "$SHARED_DIR/coding-dev.yaml" >/dev/null
+
+# Source the shared lib so we exercise the real log_to_notebook code path.
+# shellcheck source=/dev/null
+source "$SHARED_DIR/ralph-lib.sh"
+
+# emit_as <branch> <message>: emit one entry as the ralph-<branch> writer into
+# the shared notebook, exactly as a loop on that branch would.
+emit_as() {
+    local branch="$1" message="$2"
+    local BRANCH="$branch"
+    local CONTEXT="$branch"
+    log_to_notebook "impl" "$message"
+}
+
+###############################################################################
+echo "== Two loops on different branches emit into ONE shared notebook =="
+###############################################################################
+emit_as "ralph/loop-a" "loop A: entry from branch a"
+emit_as "ralph/loop-b" "loop B: entry from branch b"
+
+ENTRIES_DIR="$NOTEBOOK_DIR/entries"
+[[ -d "$ENTRIES_DIR" ]] || fail "no entries/ dir under shared notebook ($ENTRIES_DIR)"
+
+# Each writer must have its own JSONL — proves disambiguation, no collision.
+A_JSONL="$ENTRIES_DIR/ralph-loop-a.jsonl"
+B_JSONL="$ENTRIES_DIR/ralph-loop-b.jsonl"
+[[ -f "$A_JSONL" ]] || fail "missing per-writer file for loop A: $A_JSONL (have: $(ls "$ENTRIES_DIR"))"
+[[ -f "$B_JSONL" ]] || fail "missing per-writer file for loop B: $B_JSONL (have: $(ls "$ENTRIES_DIR"))"
+# They must be DISTINCT files (no collapse into one $USER.jsonl).
+[[ "$A_JSONL" != "$B_JSONL" ]] || fail "writer files are not distinct"
+# No $USER.jsonl should exist — provenance went to the per-branch writers.
+USER_JSONL="$ENTRIES_DIR/${USER:-unknown}.jsonl"
+[[ ! -f "$USER_JSONL" ]] || fail "entries leaked into a \$USER writer file: $USER_JSONL"
+pass "two distinct per-writer files: $(basename "$A_JSONL"), $(basename "$B_JSONL"); no \$USER file"
+
+###############################################################################
+echo "== A single lab-notebook sql returns BOTH entries, none lost =="
+###############################################################################
+# The entries table's writer column is `writer_id`. The sql command may print
+# an "Index rebuilt: N entries" banner and a "(N rows)" footer around the data,
+# so we match on the substrings we expect rather than parsing exact layout.
+ROWS=$(LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook sql \
+    "SELECT writer_id, content FROM entries WHERE content LIKE 'loop %' ORDER BY writer_id" 2>/dev/null || true)
+
+# Total entries across both writers must be exactly 2 (nothing lost/overwritten).
+# COUNT(*) is a single value column; isolate the data line (a bare integer) from
+# any banner/footer text.
+TOTAL=$(LAB_NOTEBOOK_DIR="$NOTEBOOK_DIR" lab-notebook sql \
+    "SELECT COUNT(*) FROM entries WHERE content LIKE 'loop %'" 2>/dev/null \
+    | grep -Eo '^[0-9]+$' | head -1)
+[[ "$TOTAL" == "2" ]] || fail "expected 2 entries across writers, found '$TOTAL'; rows:
+$ROWS"
+
+# Both writers must appear in the single query result.
+echo "$ROWS" | grep -q "ralph-loop-a" || fail "loop A entry not returned by sql; rows:
+$ROWS"
+echo "$ROWS" | grep -q "ralph-loop-b" || fail "loop B entry not returned by sql; rows:
+$ROWS"
+# And the actual message content for each writer survived.
+echo "$ROWS" | grep -q "loop A: entry from branch a" || fail "loop A content missing; rows:
+$ROWS"
+echo "$ROWS" | grep -q "loop B: entry from branch b" || fail "loop B content missing; rows:
+$ROWS"
+pass "single sql returns both writers' entries (count=2); no lost entries"
+
+echo ""
+echo "PASS: shared-notebook per-writer concurrency holds."

--- a/tests/prompt-diff.sh
+++ b/tests/prompt-diff.sh
@@ -72,7 +72,7 @@ capture_headless_prompt() {
         local SHARED_DIR="$REPO_DIR/shared"
         local PROMPT_FILE="$SHARED_DIR/PROMPT.md"
         local TASK_FILE="tasks.json"
-        local NOTEBOOK_DIR=".lnb"
+        local NOTEBOOK_DIR=".ralph/.lnb"
         local CONTEXT=""
         local ARCHIVE_DIR="archive"
         local LAST_BRANCH_FILE=".ralph-last-branch"

--- a/tests/prompt-diff.sh
+++ b/tests/prompt-diff.sh
@@ -74,8 +74,8 @@ capture_headless_prompt() {
         local TASK_FILE="tasks.json"
         local NOTEBOOK_DIR=".ralph/.lnb"
         local CONTEXT=""
-        local ARCHIVE_DIR="archive"
-        local LAST_BRANCH_FILE=".ralph-last-branch"
+        local ARCHIVE_DIR=".ralph/archive"
+        local STATE_FILE=".ralph/state.json"
 
         # shellcheck source=/dev/null
         source "$SHARED_DIR/ralph-lib.sh"

--- a/tests/prompt-diff.sh
+++ b/tests/prompt-diff.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Byte-identical prompt regression test.
+#
+# Asserts two contracts that are otherwise guarded only by a comment in
+# cc/ralph-prep.sh:
+#
+#   1. The two runners build BYTE-IDENTICAL prompts:
+#        - cc-headless/ralph.sh pipes build_prompt to `claude -p` (ralph.sh:152)
+#        - cc/ralph-prep.sh writes the same bytes to a file (ralph-prep.sh:125)
+#      We reconstruct the headless runner's prompt by sourcing the shared lib
+#      and calling build_prompt the same way ralph.sh does (path A), and we run
+#      cc/ralph-prep.sh and read the file it actually writes (path B). They must
+#      cmp/diff identical, exact bytes — no whitespace/case normalization.
+#
+#   2. Ordering: history is queried BEFORE the iteration's own `start` entry is
+#      logged, so the prompt's "Recent History" block never contains the current
+#      iteration's own start line.
+#
+# Mechanics (mirrors tests/setup-sandbox.sh):
+#   - Resolve the repo via BASH_SOURCE, never `which ralph` (the installed ralph
+#     may resolve to a different checkout).
+#   - Run each capture in its own throwaway $TMPDIR sandbox seeded with
+#     tests/tasks.json; clean up on exit. Works in a plain non-git dir (ralph is
+#     git-optional; nothing here invokes git).
+#   - Read the prompt-out path from a SINGLE source: the line ralph-prep.sh
+#     prints to stdout ("Wrote iteration N prompt to <PATH>"). When handoff 03
+#     moves the file (e.g. to .ralph/prompt.md) this test follows automatically.
+#   - Neutralize the time-varying recent_history input by running each capture
+#     against a fresh, empty notebook so query_recent_history returns the same
+#     constant string for both runners. (Empirically that string is "(no
+#     results)", not "(no history yet)" — but the test does not hardcode it; it
+#     relies only on both runners querying the same empty store.)
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --- Sandbox bookkeeping ---
+# A single parent-owned temp root holds every sandbox + scratch file. Some
+# sandboxes are created inside subshells (path A runs in a subshell so the
+# sourced lib + vars don't leak), and a subshell can't mutate a parent array —
+# so we rm the whole root in the trap rather than tracking individual dirs.
+WORKROOT="${TMPDIR:-/tmp}/ralph-promptdiff-$(date +%Y%m%d-%H%M%S)-$$"
+mkdir -p "$WORKROOT"
+cleanup() { cd /; rm -rf "$WORKROOT"; }
+trap cleanup EXIT
+
+new_sandbox() {
+    # Echoes a fresh sandbox under $WORKROOT, seeded with tests/tasks.json.
+    local sb
+    sb="$(mktemp -d "$WORKROOT/sandbox.XXXXXX")"
+    cp "$REPO_DIR/tests/tasks.json" "$sb/tasks.json"
+    echo "$sb"
+}
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+# --- Path A: reconstruct the headless runner's prompt (mirrors ralph.sh) ---
+# Runs in its own fresh sandbox against an empty notebook, then prints the
+# built prompt to stdout. Subshell so the sourced lib + vars don't leak.
+capture_headless_prompt() {
+    local out="$1"
+    (
+        local sb
+        sb="$(new_sandbox)"
+        cd "$sb"
+
+        # The same vars the runners resolve before sourcing the lib.
+        local SHARED_DIR="$REPO_DIR/shared"
+        local PROMPT_FILE="$SHARED_DIR/PROMPT.md"
+        local TASK_FILE="tasks.json"
+        local NOTEBOOK_DIR=".lnb"
+        local CONTEXT=""
+        local ARCHIVE_DIR="archive"
+        local LAST_BRANCH_FILE=".ralph-last-branch"
+
+        # shellcheck source=/dev/null
+        source "$SHARED_DIR/ralph-lib.sh"
+
+        local BRANCH PROJECT
+        BRANCH=$(read_task_meta "branch")
+        PROJECT=$(read_task_meta "project")
+        if [[ -z "$CONTEXT" ]]; then
+            if [[ -n "$BRANCH" ]]; then
+                CONTEXT="$BRANCH"
+            elif [[ -n "$PROJECT" ]]; then
+                CONTEXT="$PROJECT"
+            else
+                CONTEXT="ralph-dev"
+            fi
+        fi
+
+        # Mirror ralph.sh's main path: bookkeeping, then RECALL + build.
+        archive_previous_run
+        ensure_notebook
+        local history
+        history=$(query_recent_history)   # empty notebook -> constant string
+        build_prompt "$history"
+    ) > "$out"
+}
+
+# --- Path B: run cc/ralph-prep.sh and read the file it writes ---
+# Returns the absolute path to the prompt file written by ralph-prep.sh, by
+# parsing the single status line it prints. The cwd is left at the sandbox so
+# a relative path the runner reports still resolves.
+PREP_PROMPT_PATH=""
+run_prep() {
+    local sb status rel
+    sb="$(new_sandbox)"
+    cd "$sb"
+    # Only stdout carries the status line; diagnostics + the start-entry echo
+    # go to stderr.
+    status=$("$REPO_DIR/cc/ralph-prep.sh" --task-file tasks.json "$@")
+    rel=$(printf '%s\n' "$status" | sed -n 's/^Wrote iteration [0-9]* prompt to //p')
+    [[ -n "$rel" ]] || fail "could not parse prompt path from ralph-prep.sh stdout: [$status]"
+    # Resolve relative to the sandbox cwd we are still in.
+    if [[ "$rel" = /* ]]; then
+        PREP_PROMPT_PATH="$rel"
+    else
+        PREP_PROMPT_PATH="$sb/${rel#./}"
+    fi
+    [[ -f "$PREP_PROMPT_PATH" ]] || fail "ralph-prep.sh reported '$rel' but no file at '$PREP_PROMPT_PATH'"
+}
+
+###############################################################################
+# Assertion 1: byte-identical prompts
+###############################################################################
+echo "== Assertion 1: cc-headless/ralph.sh and cc/ralph-prep.sh build byte-identical prompts =="
+
+A_PROMPT="$WORKROOT/headless-prompt.md"
+
+capture_headless_prompt "$A_PROMPT"
+run_prep
+B_PROMPT="$PREP_PROMPT_PATH"
+
+# Exact comparison only: cmp for the byte verdict, diff to print the offender.
+if cmp -s "$A_PROMPT" "$B_PROMPT"; then
+    echo "  OK: prompts are byte-identical"
+else
+    echo "  Prompts DIFFER (headless reconstruction <  > ralph-prep.sh output):" >&2
+    diff "$A_PROMPT" "$B_PROMPT" >&2 || true
+    fail "byte-identical prompt contract broken"
+fi
+
+###############################################################################
+# Assertion 2: ordering — history queried before the iteration's own start log
+###############################################################################
+echo "== Assertion 2: prompt history excludes the current iteration's own start entry =="
+
+# Seed iteration 1 (writes one `start` entry), then run iteration 2 in the SAME
+# notebook. Iteration 2's prompt history must contain iteration 1's start line
+# (proving history is read) but NOT iteration 2's own start line (proving the
+# query happens before the start is logged).
+ORDER_SB="$(new_sandbox)"
+cd "$ORDER_SB"
+"$REPO_DIR/cc/ralph-prep.sh" --task-file tasks.json --iteration 1 --max-iterations 2 >/dev/null 2>&1
+
+status=$("$REPO_DIR/cc/ralph-prep.sh" --task-file tasks.json --iteration 2 --max-iterations 2)
+rel=$(printf '%s\n' "$status" | sed -n 's/^Wrote iteration [0-9]* prompt to //p')
+[[ -n "$rel" ]] || fail "could not parse prompt path from ralph-prep.sh (iter 2): [$status]"
+if [[ "$rel" = /* ]]; then ORDER_PROMPT="$rel"; else ORDER_PROMPT="$ORDER_SB/${rel#./}"; fi
+[[ -f "$ORDER_PROMPT" ]] || fail "iteration-2 prompt not found at '$ORDER_PROMPT'"
+
+# Isolate the Recent History section so we only inspect history, not the rest
+# of the prompt template (which also mentions `start`).
+HISTORY_BLOCK=$(awk '
+    /^## Recent History/ { inblock=1; next }
+    /^## / { if (inblock) inblock=0 }
+    inblock { print }
+' "$ORDER_PROMPT")
+
+if ! printf '%s\n' "$HISTORY_BLOCK" | grep -q "iteration 1/2"; then
+    echo "  Recent History block was:" >&2
+    printf '%s\n' "$HISTORY_BLOCK" >&2
+    fail "iteration-2 history does not contain iteration 1's start entry (history not being read?)"
+fi
+if printf '%s\n' "$HISTORY_BLOCK" | grep -q "iteration 2/2"; then
+    echo "  Recent History block was:" >&2
+    printf '%s\n' "$HISTORY_BLOCK" >&2
+    fail "iteration-2 history contains its OWN start entry — start was logged before history was queried"
+fi
+echo "  OK: history has the prior start entry and not the current one"
+
+echo ""
+echo "PASS: prompt-diff contracts hold."

--- a/tests/upgrade.sh
+++ b/tests/upgrade.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-time OLD-layout -> .ralph/ upgrade shim test (handoff 08).
+#
+# Older installs scattered ralph state across the project root:
+#   ./.lnb/              notebook         -> .ralph/.lnb
+#   ./.lnb.env           pointer (abs)    -> rewritten to point at .ralph/.lnb
+#   ./.ralph-last-branch bare branch cur. -> .ralph/state.json
+#   ./archive/           old snapshots    -> .ralph/archive
+#
+# migrate_old_layout migrates such a tree ONCE without data loss and is a clean
+# no-op afterwards. Both runners call it (before archive bookkeeping, and again
+# at the top of ensure_notebook). This test exercises it two ways:
+#
+#   PART A — the shim in isolation (source ralph-lib.sh, call migrate_old_layout
+#   directly): proves the precise migration outcome, incl. that state.json
+#   carries the OLD branch verbatim, and that a SECOND call is a clean no-op
+#   (idempotence) and a half-migrated tree converges.
+#
+#   PART B — end-to-end through cc/ralph-prep.sh (the runnable bookkeeping entry
+#   point — reaches migrate_old_layout + archive_previous_run + ensure_notebook
+#   without needing `claude`): proves a real run migrates the layout, then the
+#   migrated OLD branch drives archive_previous_run to snapshot under an
+#   old-branch-named archive folder, and a second run is a clean no-op.
+#
+# Everything runs in plain NON-GIT dirs (ralph is git-optional; nothing here
+# invokes git).
+#
+# Mechanics (mirrors tests/archive.sh / tests/setup-sandbox.sh):
+#   - Resolve the repo via BASH_SOURCE, never `which ralph` (the installed
+#     ralph may resolve to a different checkout).
+#   - Throwaway $TMPDIR workroot; clean up on exit.
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PREP="$REPO_DIR/cc/ralph-prep.sh"
+SHARED_DIR="$REPO_DIR/shared"
+TEMPLATE="$SHARED_DIR/coding-dev.yaml"
+
+if ! command -v lab-notebook &>/dev/null; then
+    echo "SKIP: lab-notebook not on PATH; cannot run upgrade test." >&2
+    exit 0
+fi
+
+WORKROOT="${TMPDIR:-/tmp}/ralph-upgrade-$(date +%Y%m%d-%H%M%S)-$$"
+mkdir -p "$WORKROOT"
+cleanup() { cd /; rm -rf "$WORKROOT"; }
+trap cleanup EXIT
+
+pass() { echo "  OK: $*"; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+# Known fixtures.
+KNOWN_ENTRY="known entry alpha (pre-migration)"
+OLD_BRANCH="ralph/old-batch"
+ARCHIVE_SNAPSHOT_REL="archive/2025-01-01-old-batch/tasks.json"
+
+# seed_old_layout <dir>: scaffold a full OLD-layout project at <dir>.
+#   ./.lnb (+ ./.lnb.env) with ONE known entry, ./.ralph-last-branch, ./archive.
+seed_old_layout() {
+    local dir="$1"
+    mkdir -p "$dir"
+    cp "$REPO_DIR/tests/tasks.json" "$dir/tasks.json"
+    (
+        cd "$dir"
+        # `lab-notebook init .` forces a /.lnb leaf and writes ./.lnb.env with an
+        # ABSOLUTE path to it — exactly the OLD on-disk shape.
+        lab-notebook init . --template-path "$TEMPLATE" >/dev/null
+        LAB_NOTEBOOK_DIR="$dir/.lnb" \
+            lab-notebook emit --context "$OLD_BRANCH" --type impl "$KNOWN_ENTRY" >/dev/null
+        printf '%s\n' "$OLD_BRANCH" > ./.ralph-last-branch
+        mkdir -p "$(dirname "$ARCHIVE_SNAPSHOT_REL")"
+        printf 'old snapshot marker\n' > "$ARCHIVE_SNAPSHOT_REL"
+    )
+    [[ -d "$dir/.lnb" && -f "$dir/.lnb.env" && -f "$dir/.ralph-last-branch" \
+        && -f "$dir/$ARCHIVE_SNAPSHOT_REL" ]] || fail "seed: OLD layout incomplete in $dir"
+}
+
+###############################################################################
+echo "== PART A: migrate_old_layout in isolation =="
+###############################################################################
+A_DIR="$WORKROOT/partA"
+seed_old_layout "$A_DIR"
+[[ ! -d "$A_DIR/.git" ]] || fail "partA sandbox unexpectedly has .git"
+pass "seeded OLD layout (./.lnb + 1 entry, ./.lnb.env, ./.ralph-last-branch=$OLD_BRANCH, $ARCHIVE_SNAPSHOT_REL)"
+
+# Drive the real shim, isolated in a subshell so the sourced lib/vars don't leak.
+(
+    cd "$A_DIR"
+    STATE_FILE=".ralph/state.json"
+    # shellcheck source=/dev/null
+    source "$SHARED_DIR/ralph-lib.sh"
+    migrate_old_layout
+)
+
+# (a) Known entry queryable through .ralph/.lnb.
+[[ -d "$A_DIR/.ralph/.lnb" ]] || fail "A: .ralph/.lnb not present after migrate"
+got=$(LAB_NOTEBOOK_DIR="$A_DIR/.ralph/.lnb" lab-notebook sql \
+    "SELECT content FROM entries WHERE content='$KNOWN_ENTRY'" 2>/dev/null || true)
+echo "$got" | grep -qF "$KNOWN_ENTRY" \
+    || fail "A: known entry NOT queryable through .ralph/.lnb (history lost!); got: $got"
+pass "known entry survives the MOVE and is queryable through .ralph/.lnb"
+
+# (b) state.json carries the OLD branch verbatim and is schema-valid.
+SF="$A_DIR/.ralph/state.json"
+[[ -s "$SF" ]] || fail "A: .ralph/state.json missing"
+jq -e . "$SF" >/dev/null 2>&1 || fail "A: state.json not valid JSON"
+[[ "$(jq -r '.branch' "$SF")" == "$OLD_BRANCH" ]] \
+    || fail "A: state.json branch is '$(jq -r '.branch' "$SF")', expected '$OLD_BRANCH'"
+[[ "$(jq -r '.last_run' "$SF")" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || fail "A: state.json last_run not ISO8601: $(jq -r '.last_run' "$SF")"
+[[ "$(jq -r '.completed_branch' "$SF")" == "null" ]] \
+    || fail "A: migrated completed_branch should be null"
+# Exactly the landed schema's three keys.
+[[ "$(jq -r 'keys | sort | join(",")' "$SF")" == "branch,completed_branch,last_run" ]] \
+    || fail "A: state.json keys are '$(jq -c 'keys' "$SF")', expected branch/completed_branch/last_run"
+pass "state.json carries OLD branch ($OLD_BRANCH), schema-valid (branch/last_run/completed_branch)"
+
+# (c) Archive moved with snapshot intact.
+[[ -f "$A_DIR/.ralph/$ARCHIVE_SNAPSHOT_REL" ]] \
+    || fail "A: archive snapshot not at .ralph/$ARCHIVE_SNAPSHOT_REL"
+grep -q "old snapshot marker" "$A_DIR/.ralph/$ARCHIVE_SNAPSHOT_REL" \
+    || fail "A: archive snapshot content lost"
+pass "./archive moved to .ralph/archive with snapshot intact"
+
+# (d) Old root files gone; .lnb.env repointed to the new ABSOLUTE export path.
+[[ ! -e "$A_DIR/.lnb" ]]               || fail "A: old ./.lnb still present"
+[[ ! -e "$A_DIR/.ralph-last-branch" ]] || fail "A: old ./.ralph-last-branch still present"
+[[ ! -e "$A_DIR/archive" ]]            || fail "A: old ./archive still present"
+NEW_ABS="$A_DIR/.ralph/.lnb"
+env_val=$(sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?LAB_NOTEBOOK_DIR=//p' "$A_DIR/.lnb.env" | head -1)
+[[ "$env_val" == "$NEW_ABS" ]] \
+    || fail "A: .lnb.env LAB_NOTEBOOK_DIR is '$env_val', expected absolute '$NEW_ABS'"
+grep -q '^export LAB_NOTEBOOK_DIR=' "$A_DIR/.lnb.env" \
+    || fail "A: .lnb.env not in 'export LAB_NOTEBOOK_DIR=...' init format"
+pass "old root files gone; .lnb.env -> $NEW_ABS (absolute, export format)"
+
+# (e) Discovery via .lnb.env (no explicit env var) resolves the migrated notebook.
+disc=$(cd "$A_DIR" && lab-notebook sql \
+    "SELECT content FROM entries WHERE content='$KNOWN_ENTRY'" 2>/dev/null || true)
+echo "$disc" | grep -qF "$KNOWN_ENTRY" \
+    || fail "A: discovery via .lnb.env broken (entry not found); got: $disc"
+pass "notebook discovery via .lnb.env resolves the migrated notebook"
+
+# (f) Idempotence: a SECOND migrate_old_layout is a clean no-op.
+snapshot() { ( cd "$A_DIR" && find .ralph .lnb.env -printf '%P\t%s\t%T@\n' 2>/dev/null | sort ); }
+before=$(snapshot)
+env_before=$(cat "$A_DIR/.lnb.env")
+state_before=$(cat "$SF")
+A2LOG="$WORKROOT/partA-run2.log"
+(
+    cd "$A_DIR"
+    STATE_FILE=".ralph/state.json"
+    # shellcheck source=/dev/null
+    source "$SHARED_DIR/ralph-lib.sh"
+    migrate_old_layout
+) >"$A2LOG" 2>&1
+grep -qi 'Migrated ' "$A2LOG" && fail "A: second migrate re-migrated (not idempotent): $(cat "$A2LOG")"
+[[ "$(snapshot)" == "$before" ]] || { diff <(printf '%s\n' "$before") <(printf '%s\n' "$(snapshot)") >&2; fail "A: second migrate mutated the .ralph tree"; }
+[[ "$(cat "$A_DIR/.lnb.env")" == "$env_before" ]] || fail "A: second migrate changed .lnb.env"
+[[ "$(cat "$SF")" == "$state_before" ]] || fail "A: second migrate changed state.json"
+pass "second migrate_old_layout is a CLEAN no-op (no Migrated lines; tree/.lnb.env/state unchanged)"
+
+# (g) Partial-migration convergence: a tree where the notebook is migrated but
+#     the OLD cursor + archive linger must converge without clobbering the
+#     already-migrated notebook (and without erroring under set -euo pipefail).
+P_DIR="$WORKROOT/partial"
+seed_old_layout "$P_DIR"
+# Simulate an interrupted migration: notebook already moved (+ pointer fixed),
+# but ./.ralph-last-branch and ./archive still at root and no state.json yet.
+mkdir -p "$P_DIR/.ralph"
+mv "$P_DIR/.lnb" "$P_DIR/.ralph/.lnb"
+printf '# Project-local lab-notebook configuration\nexport LAB_NOTEBOOK_DIR=%s\n' \
+    "$P_DIR/.ralph/.lnb" > "$P_DIR/.lnb.env"
+# Mark the already-migrated notebook so we can prove it is NOT clobbered.
+P_NB_MTIME_BEFORE=$(stat -c '%Y' "$P_DIR/.ralph/.lnb")
+(
+    cd "$P_DIR"
+    STATE_FILE=".ralph/state.json"
+    # shellcheck source=/dev/null
+    source "$SHARED_DIR/ralph-lib.sh"
+    migrate_old_layout
+)
+# Notebook must be untouched (no re-move / re-init); its entry still queryable.
+gotp=$(LAB_NOTEBOOK_DIR="$P_DIR/.ralph/.lnb" lab-notebook sql \
+    "SELECT content FROM entries WHERE content='$KNOWN_ENTRY'" 2>/dev/null || true)
+echo "$gotp" | grep -qF "$KNOWN_ENTRY" || fail "partial: notebook clobbered (entry lost)"
+[[ "$(stat -c '%Y' "$P_DIR/.ralph/.lnb")" == "$P_NB_MTIME_BEFORE" ]] \
+    || fail "partial: .ralph/.lnb was re-moved (mtime changed) despite already being migrated"
+# The lingering OLD cursor + archive must now be converged.
+[[ "$(jq -r '.branch' "$P_DIR/.ralph/state.json")" == "$OLD_BRANCH" ]] \
+    || fail "partial: cursor not converged from lingering ./.ralph-last-branch"
+[[ ! -e "$P_DIR/.ralph-last-branch" ]] || fail "partial: ./.ralph-last-branch not removed"
+[[ -f "$P_DIR/.ralph/$ARCHIVE_SNAPSHOT_REL" ]] || fail "partial: ./archive not converged"
+[[ ! -e "$P_DIR/archive" ]] || fail "partial: ./archive not removed"
+pass "partial-migration tree converges: notebook untouched, cursor + archive completed"
+
+###############################################################################
+echo "== PART B: end-to-end through cc/ralph-prep.sh =="
+###############################################################################
+B_DIR="$WORKROOT/partB"
+seed_old_layout "$B_DIR"
+[[ ! -d "$B_DIR/.git" ]] || fail "partB sandbox unexpectedly has .git"
+cd "$B_DIR"
+
+# Run 1: migrate, then archive_previous_run sees the migrated OLD branch as the
+# cursor and the CURRENT tasks.json branch (ralph/smoke-test) as a transition.
+BLOG1="$WORKROOT/partB-run1.log"
+"$PREP" --task-file tasks.json --iteration 1 >"$BLOG1" 2>&1 \
+    || fail "B run 1 exited non-zero: $(cat "$BLOG1")"
+
+# The shim reported the migration.
+grep -qi 'Migrated notebook' "$BLOG1" || fail "B: run 1 did not report notebook migration: $(cat "$BLOG1")"
+
+# Notebook history survived end-to-end.
+gotb=$(LAB_NOTEBOOK_DIR="$B_DIR/.ralph/.lnb" lab-notebook sql \
+    "SELECT content FROM entries WHERE content='$KNOWN_ENTRY'" 2>/dev/null || true)
+echo "$gotb" | grep -qF "$KNOWN_ENTRY" || fail "B: known entry lost end-to-end"
+
+# Old root files gone; .lnb.env repointed.
+[[ ! -e ./.lnb && ! -e ./.ralph-last-branch && ! -e ./archive ]] \
+    || fail "B: old root artifacts not removed (ls: $(ls -a))"
+NEW_ABS_B="$B_DIR/.ralph/.lnb"
+env_val_b=$(sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?LAB_NOTEBOOK_DIR=//p' ./.lnb.env | head -1)
+[[ "$env_val_b" == "$NEW_ABS_B" ]] || fail "B: .lnb.env -> '$env_val_b', expected '$NEW_ABS_B'"
+
+# The migrated OLD branch drove archive_previous_run: a transition from
+# ralph/old-batch to ralph/smoke-test snapshots tasks.json under an
+# old-branch-named folder. (branch_slug strips 'ralph/' -> 'old-batch'.)
+DATE_STR="$(date +%Y-%m-%d)"
+TRANS_FOLDER=".ralph/archive/$DATE_STR-old-batch"
+[[ -f "$TRANS_FOLDER/tasks.json" ]] \
+    || fail "B: migrated OLD branch did not drive a transition archive at $TRANS_FOLDER (have: $(ls -R .ralph/archive 2>/dev/null))"
+# The pre-existing OLD snapshot also still lives under .ralph/archive.
+[[ -f ".ralph/$ARCHIVE_SNAPSHOT_REL" ]] || fail "B: pre-existing OLD snapshot lost from archive"
+# After the transition, the cursor advanced to the current branch.
+[[ "$(jq -r '.branch' .ralph/state.json)" == "ralph/smoke-test" ]] \
+    || fail "B: cursor did not advance to ralph/smoke-test after transition"
+pass "run 1: migrated; OLD branch drove a transition archive ($TRANS_FOLDER); cursor advanced"
+
+# Run 2: clean no-op for the shim. The migration is idempotent: no "Migrated"
+# lines, no old artifacts reappear, the .lnb.env pointer the shim wrote is
+# byte-identical, and the migrated notebook is NOT re-moved (its inode is
+# stable — a re-move would change it). We do NOT assert the whole notebook tree
+# is byte-stable: ralph-prep legitimately emits a `start` entry + rebuilds the
+# index every run; that's normal notebook activity, not the shim.
+nb_inode_before=$(stat -c '%i' .ralph/.lnb)
+env_b2_before=$(cat ./.lnb.env)
+BLOG2="$WORKROOT/partB-run2.log"
+"$PREP" --task-file tasks.json --iteration 2 >"$BLOG2" 2>&1 \
+    || fail "B run 2 exited non-zero: $(cat "$BLOG2")"
+grep -qi 'Migrated ' "$BLOG2" && fail "B: run 2 re-migrated (shim not idempotent): $(grep -i 'Migrated ' "$BLOG2")"
+[[ ! -e ./.lnb && ! -e ./.ralph-last-branch && ! -e ./archive ]] \
+    || fail "B: old artifacts reappeared on run 2"
+[[ "$(stat -c '%i' .ralph/.lnb)" == "$nb_inode_before" ]] \
+    || fail "B: .ralph/.lnb was re-moved on run 2 (inode changed)"
+[[ "$(cat ./.lnb.env)" == "$env_b2_before" ]] || fail "B: .lnb.env changed on run 2"
+# Same-branch run created no NEW transition folder.
+NEW_TRANS=$(find .ralph/archive -maxdepth 1 -type d -name "$DATE_STR-smoke-test" 2>/dev/null)
+[[ -z "$NEW_TRANS" ]] || fail "B: same-branch run 2 created a spurious archive: $NEW_TRANS"
+gotb2=$(LAB_NOTEBOOK_DIR="$B_DIR/.ralph/.lnb" lab-notebook sql \
+    "SELECT content FROM entries WHERE content='$KNOWN_ENTRY'" 2>/dev/null || true)
+echo "$gotb2" | grep -qF "$KNOWN_ENTRY" || fail "B: known entry lost after no-op run 2"
+pass "run 2 is a clean no-op: no re-migration, shim files + .lnb.env unchanged, entry intact"
+
+###############################################################################
+echo "== No git was invoked anywhere (git-optional) =="
+###############################################################################
+for d in "$A_DIR" "$P_DIR" "$B_DIR"; do
+    [[ ! -d "$d/.git" ]] || fail "a .git dir appeared in $d (git was invoked?)"
+done
+pass "ran entirely in non-git dirs; no .git created"
+
+echo ""
+echo "PASS: upgrade shim migrates OLD layout once, preserves data, converges partial trees, and is idempotent."

--- a/tests/upgrade.sh
+++ b/tests/upgrade.sh
@@ -195,6 +195,60 @@ echo "$gotp" | grep -qF "$KNOWN_ENTRY" || fail "partial: notebook clobbered (ent
 [[ ! -e "$P_DIR/archive" ]] || fail "partial: ./archive not removed"
 pass "partial-migration tree converges: notebook untouched, cursor + archive completed"
 
+# (h) Dangling-pointer reconciliation: an interrupted run moved ./.lnb ->
+#     .ralph/.lnb but died BEFORE rewriting .lnb.env, leaving the pointer at the
+#     now-missing ./.lnb. A later migrate must repoint it at .ralph/.lnb so a
+#     bare discovery (no explicit env var) still resolves the notebook.
+H_DIR="$WORKROOT/dangling"
+seed_old_layout "$H_DIR"
+OLD_ABS_LNB="$H_DIR/.lnb"
+mkdir -p "$H_DIR/.ralph"
+mv "$H_DIR/.lnb" "$H_DIR/.ralph/.lnb"
+# Pointer left dangling at the OLD absolute path (the interrupted-move bug).
+printf '# Project-local lab-notebook configuration\nexport LAB_NOTEBOOK_DIR=%s\n' \
+    "$OLD_ABS_LNB" > "$H_DIR/.lnb.env"
+[[ ! -d "$OLD_ABS_LNB" ]] || fail "h: precondition — old ./.lnb should be gone"
+(
+    cd "$H_DIR"
+    STATE_FILE=".ralph/state.json"
+    # shellcheck source=/dev/null
+    source "$SHARED_DIR/ralph-lib.sh"
+    migrate_old_layout
+)
+H_ABS="$H_DIR/.ralph/.lnb"
+h_env=$(sed -n 's/^[[:space:]]*\(export[[:space:]]\+\)\?LAB_NOTEBOOK_DIR=//p' "$H_DIR/.lnb.env" | head -1)
+[[ "$h_env" == "$H_ABS" ]] \
+    || fail "h: dangling pointer not reconciled; .lnb.env is '$h_env', expected '$H_ABS'"
+hdisc=$(cd "$H_DIR" && lab-notebook sql \
+    "SELECT content FROM entries WHERE content='$KNOWN_ENTRY'" 2>/dev/null || true)
+echo "$hdisc" | grep -qF "$KNOWN_ENTRY" \
+    || fail "h: discovery via reconciled .lnb.env broken; got: $hdisc"
+pass "dangling .lnb.env pointer reconciled to .ralph/.lnb after an interrupted move"
+
+# (i) Both-notebooks-exist: a stale ./.lnb lingering alongside an already-migrated
+#     .ralph/.lnb must be LEFT IN PLACE (never deleted/merged) with a loud warning
+#     — silent orphaning of the old history is the failure mode being guarded.
+I_DIR="$WORKROOT/bothexist"
+seed_old_layout "$I_DIR"
+mkdir -p "$I_DIR/.ralph"
+cp -a "$I_DIR/.lnb" "$I_DIR/.ralph/.lnb"   # already-migrated copy present...
+[[ -d "$I_DIR/.lnb" && -d "$I_DIR/.ralph/.lnb" ]] \
+    || fail "i: precondition — both notebooks should exist"   # ...and ./.lnb still lingers
+ILOG="$WORKROOT/bothexist.log"
+(
+    cd "$I_DIR"
+    STATE_FILE=".ralph/state.json"
+    # shellcheck source=/dev/null
+    source "$SHARED_DIR/ralph-lib.sh"
+    migrate_old_layout
+) >"$ILOG" 2>&1
+grep -qiF 'both ./.lnb and .ralph/.lnb exist' "$ILOG" \
+    || fail "i: expected a both-exist WARNING; got: $(cat "$ILOG")"
+[[ -d "$I_DIR/.lnb" ]] \
+    || fail "i: stale ./.lnb was destroyed (history must be preserved, not deleted)"
+[[ -d "$I_DIR/.ralph/.lnb" ]] || fail "i: .ralph/.lnb disturbed"
+pass "both-notebooks-exist: ./.lnb preserved untouched with a loud warning (no silent data loss)"
+
 ###############################################################################
 echo "== PART B: end-to-end through cc/ralph-prep.sh =="
 ###############################################################################


### PR DESCRIPTION
## What

Consolidates everything ralph generates into one gitignored `.ralph/` directory, closing the state leaks the old layout scattered into the project root. Implements the design in `handoffs/ralph-state-layout.md`.

**Layout after this PR:** `tasks.json` (+ a small `.lnb.env` pointer) stays at the project root; everything ralph generates lives under `.ralph/` — `.ralph/.lnb` (notebook), `.ralph/prompt.md`, `.ralph/state.json` (cursor), `.ralph/archive/`. `.gitignore` shrinks to `.lnb.env` + `.ralph/`. The previously-leaking `.ralph-last-branch` and `archive/` are gone.

## Commits (one per wave, 8 handoffs)

- **Wave A** — byte-identical prompt regression test (`tests/prompt-diff.sh`) + design-spec amendment
- **Wave B** — prompt → `.ralph/prompt.md`; notebook → `.ralph/.lnb` (single `lab-notebook init .ralph`, deletes the brittle mv+sed hack); both runners' `NOTEBOOK_DIR` default flipped together
- **Wave C** — `.ralph-last-branch` → `.ralph/state.json`; resolved archive trigger; stop copying the notebook on archive; record batch completion + refuse all-green re-spin (`--force` to override)
- **Wave D** — per-loop writer `ralph-<branch>` (not `$USER`); opt-in shared notebook via existing `--notebook`; `tests/concurrency.sh`
- **Wave E** — doc-truth sweep (README, skill template, tests/README) to match the landed layout
- **Wave F** — idempotent upgrade shim: migrates old on-disk layout to `.ralph/` once, then no-ops

## Verification

- `tests/prompt-diff.sh`, `tests/archive.sh`, `tests/concurrency.sh`, `tests/upgrade.sh` all exit 0
- `ralph --max-iterations 1` completes end-to-end in a plain non-git dir, producing the target layout with the `ralph-<branch>` writer and zero leak files
- ralph kept git-optional throughout (no `git` in the runtime path)

## ⚠️ Post-merge manual step

`skill/SKILL.md.template` changed, so after merging you must **re-run `install.sh`** (from the canonical clone, against `master`) to re-render `~/.claude/skills/ralph-lnb/SKILL.md`, then restart Claude Code sessions to pick up the new skill.

## Note

The `handoffs/` planning directory (the migration plan + the amended design spec) is intentionally left untracked/out of this PR — it's scaffolding, not product. Say the word if you'd like the design spec committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)